### PR TITLE
Update to .NET 8, update vulnerable ImageSharp, Image Loading and bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To be honest, this project was just borne out of having a few different ideas of
 
 ### Build
 
-If you're feeling adventurous and want to build this for yourself, make sure you have the .NET 6 SDK installed and ready, then just run the following:
+If you're feeling adventurous and want to build this for yourself, make sure you have the .NET 8 SDK installed and ready, then just run the following:
 
 ```bash
 dotnet tool restore

--- a/src/CensorCore.Console/CensorCommand.cs
+++ b/src/CensorCore.Console/CensorCommand.cs
@@ -7,10 +7,13 @@ using TextCopy;
 
 namespace CensorCore.Console;
 
-public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
-    public override async Task<int> ExecuteAsync(CommandContext context, CensorCommandSettings settings) {
+public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, CensorCommandSettings settings)
+    {
         var imagePath = settings.ImagePath == null ? null : Path.IsPathFullyQualified(settings.ImagePath) ? settings.ImagePath : Path.GetFullPath(settings.ImagePath);
-        if (imagePath == null || !File.Exists(imagePath)) {
+        if (imagePath == null || !File.Exists(imagePath))
+        {
             AnsiConsole.MarkupLine("[red]ERROR! [/] Could not load source image file!");
             AnsiConsole.MarkupLine($"Please ensure the '[grey]{imagePath}[/]' file exists and try again!");
             return 404;
@@ -21,21 +24,26 @@ public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
             .SearchAssembly(typeof(CensorCommand).Assembly)
             .Build();
         var model = await loader.GetLocalModel(settings.ModelFilePath);
-        if (model == null && settings.AllowDownload) {
+        if (model == null && settings.AllowDownload)
+        {
             AnsiConsole.MarkupLine($"Downloading model files from GitHub! This should only be required once.");
-            try {
+            try
+            {
                 var dl = await loader.DownloadModel(true);
-                if (dl.HasValue) {
+                if (dl.HasValue)
+                {
                     AnsiConsole.MarkupLine($"Downloaded [green]'{dl.Value.FileName}'[/] from GitHub, ready to use.");
                     model = dl.Value.ModelData;
                 }
             }
-            catch (Exception e) {
+            catch (Exception e)
+            {
                 AnsiConsole.MarkupLine("[darkred]WARN:[/] Failed to download model files from GitHub!");
                 AnsiConsole.MarkupLine($"[grey]Exception: {e.Message} ({e.ToString()})");
             }
         }
-        if (model == null) {
+        if (model == null)
+        {
             AnsiConsole.MarkupLine("[red]ERROR! [/] Could not load model file!");
             AnsiConsole.MarkupLine("Download the model to a searched location, set [grey]--download[/] or pass [grey]--model-file[/] to specify a model file!");
             return 412;
@@ -44,24 +52,27 @@ public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
         var handler = new BodyAreaImageHandler(new ImageSharpHandler(1000, 1000), settings.OptimizationMode);
         AnsiConsole.MarkupLine("Preparing AI service and censoring components");
         var svc = Runtime.AIRuntime.CreateService(model, handler, settings.EnableAcceleration);
-        if (settings.Verbose) {
+        if (settings.Verbose)
+        {
             svc.Verbose = true;
         }
-        var globalOpts = new GlobalCensorOptions {RelativeCensorScale = 1F};
+        var globalOpts = new GlobalCensorOptions { RelativeCensorScale = 1F };
         var blur = new BlurProvider(globalOpts);
         var pixel = new PixelationProvider(globalOpts);
         var bars = new BlackBarProvider();
         var stickers = new StickerProvider(new EmptyAssetStore(), globalOpts);
         var caption = new CaptionProvider(new EmptyAssetStore(), null, globalOpts);
-        var transformers = new IResultsTransformer[] {new CensorScaleTransformer(globalOpts), new IntersectingMatchMerger() };
-        var middleware = new ICensoringMiddleware[] { new FacialFeaturesMiddleware(new EmptyAssetStore()), new GifWatermarkMiddleware()};
+        var transformers = new IResultsTransformer[] { new CensorScaleTransformer(globalOpts), new IntersectingMatchMerger() };
+        var middleware = new ICensoringMiddleware[] { new FacialFeaturesMiddleware(new EmptyAssetStore()), new GifWatermarkMiddleware() };
         var cens = new ImageSharpCensoringProvider(new ICensorTypeProvider[] { blur, pixel, bars, stickers, caption }, transformers: settings.NoTransformers ? Array.Empty<IResultsTransformer>() : transformers, middlewares: middleware);
 
         AnsiConsole.MarkupLine("Invoking model...");
         var result = await svc.RunModel(imagePath);
-        if (result != null) {
+        if (result != null)
+        {
             AnsiConsole.MarkupLine($"Successfully matched image with [blue]{result.Results.Count}[/] matches found.");
-            if (result.Session != null && !svc.Verbose) {
+            if (result.Session != null && !svc.Verbose)
+            {
                 // if the service is in verbose mode, these timings will have already been output!
                 var table = GetTable(result.Session);
                 AnsiConsole.Write(table);
@@ -69,16 +80,21 @@ public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
             }
             CensoredImage? censoredResult = null;
             IResultParser? parser = null;
-            if (settings.Verbose) {
+            if (settings.Verbose)
+            {
                 AnsiConsole.Write(GetTree(result, imagePath));
             }
-            if (settings.OverrideFilePath != null) {
+            if (settings.OverrideFilePath != null)
+            {
                 var oParser = new OverrideFileParser(settings.OverrideFilePath);
                 var loaded = await oParser.Load();
-                if (loaded && oParser._overrides != null) {
+                if (loaded && oParser._overrides != null)
+                {
                     AnsiConsole.MarkupLine($"Successfully loaded [blue]{oParser._overrides.Keys.Count}[/] overrides from file.");
                     parser = oParser;
-                } else {
+                }
+                else
+                {
                     AnsiConsole.MarkupLine($"Failed to load overrides from [grey]'{Path.GetFileName(settings.OverrideFilePath)}'[/]. Continuing with defaults...");
                 }
             }
@@ -87,13 +103,15 @@ public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
             AnsiConsole.MarkupLine("Running censoring on image...");
             censoredResult = await cens.CensorImage(result, parser);
             timer.Stop();
-            if (censoredResult != null) {
+            if (censoredResult != null)
+            {
                 AnsiConsole.MarkupLine($"Completed censoring image in [blue]{timer.Elapsed.TotalSeconds}[/]s!");
                 var outputFilePath = settings.OutputPath
                     ?? Path.Combine(Environment.CurrentDirectory, $"{Path.GetFileNameWithoutExtension(imagePath)}_censored.{censoredResult.MimeType.Split("/").Last()}");
                 await File.WriteAllBytesAsync(outputFilePath, censoredResult.ImageContents);
                 AnsiConsole.MarkupLine($"Wrote censored image to '[grey]{outputFilePath}[/]'!");
-                if (settings.CopyUrlToClipboard && !string.IsNullOrWhiteSpace(censoredResult.ImageDataUrl)) {
+                if (settings.CopyUrlToClipboard && !string.IsNullOrWhiteSpace(censoredResult.ImageDataUrl))
+                {
                     AnsiConsole.MarkupLine("Copying image data URL to clipboard...");
                     await ClipboardService.SetTextAsync(censoredResult.ImageDataUrl);
                 }
@@ -103,7 +121,8 @@ public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
         return 500;
     }
 
-    public class CensorCommandSettings : CensoringSettings {
+    public class CensorCommandSettings : CensoringSettings
+    {
         [CommandArgument(0, "[imagePath]")]
         public string? ImagePath { get; set; }
 
@@ -119,41 +138,48 @@ public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
         public string? OverrideFilePath { get; set; }
     }
 
-    private Table GetTable(SessionMetadata meta) {
+    private Table GetTable(SessionMetadata meta)
+    {
         var totalTimeSpan = meta.ModelRunTime.TotalSeconds + (meta.ImageLoadTime ?? TimeSpan.FromSeconds(0)).TotalSeconds + (meta.TensorLoadTime ?? TimeSpan.FromSeconds(0)).TotalSeconds;
         var table = new Table().Border(TableBorder.Square).BorderColor(Color.Grey);
         table.AddColumn(new TableColumn("Task").LeftAligned().Footer("Total"));
         table.AddColumn(new TableColumn("Time").RightAligned().Footer(Math.Round(totalTimeSpan, 3).ToString() + "s"));
-        if (meta.ImageLoadTime != null && meta.ImageLoadTime.Value is var imageLoadTime) {
+        if (meta.ImageLoadTime != null && meta.ImageLoadTime.Value is var imageLoadTime)
+        {
             table.AddRow("Image Loading", $"{imageLoadTime.TotalSeconds.ToString()}s");
         }
-        if (meta.TensorLoadTime != null && meta.TensorLoadTime.Value is var tensorLoadTime) {
+        if (meta.TensorLoadTime != null && meta.TensorLoadTime.Value is var tensorLoadTime)
+        {
             table.AddRow("Tensor Loading", tensorLoadTime.TotalSeconds.ToString() + "s");
         }
         table.AddRow("Model Execution", meta.ModelRunTime.TotalSeconds.ToString() + "s");
         return table;
     }
 
-    private BarChart GetChart(SessionMetadata meta) {
+    private BarChart GetChart(SessionMetadata meta)
+    {
         var totalTimeSpan = meta.ModelRunTime.TotalSeconds + (meta.ImageLoadTime ?? TimeSpan.FromSeconds(0)).TotalSeconds + (meta.TensorLoadTime ?? TimeSpan.FromSeconds(0)).TotalSeconds;
         var chart = new BarChart().Width(80).Label("[blue bold underline]Execution Time[/]")
         .LeftAlignLabel().HideValues();
-        
-        if (meta.ImageLoadTime != null && meta.ImageLoadTime.Value is var imageLoadTime) {
-            var percentOfTime = (imageLoadTime.TotalSeconds / totalTimeSpan)*100;
+
+        if (meta.ImageLoadTime != null && meta.ImageLoadTime.Value is var imageLoadTime)
+        {
+            var percentOfTime = (imageLoadTime.TotalSeconds / totalTimeSpan) * 100;
             // chart.AddItem(new BarChartItem("Image Loading", 80*percentOfTime));
-            chart.AddItem("Image Loading", 80*percentOfTime);
+            chart.AddItem("Image Loading", 80 * percentOfTime);
         }
-        if (meta.TensorLoadTime != null && meta.TensorLoadTime.Value is var tensorLoadTime) {
-            var percentOfTime = (tensorLoadTime.TotalSeconds / totalTimeSpan)*100;
-            chart.AddItem("Tensor Loading", 80*percentOfTime);
+        if (meta.TensorLoadTime != null && meta.TensorLoadTime.Value is var tensorLoadTime)
+        {
+            var percentOfTime = (tensorLoadTime.TotalSeconds / totalTimeSpan) * 100;
+            chart.AddItem("Tensor Loading", 80 * percentOfTime);
         }
-        var modelPercent = (meta.ModelRunTime.TotalSeconds / totalTimeSpan)*100;
-        chart.AddItem("Model Execution", 80*modelPercent);
+        var modelPercent = (meta.ModelRunTime.TotalSeconds / totalTimeSpan) * 100;
+        chart.AddItem("Model Execution", 80 * modelPercent);
         return chart;
     }
 
-    private Tree GetTree(ImageResult<Classification> imageResult, string inputName) {
+    private Tree GetTree(ImageResult<Classification> imageResult, string inputName)
+    {
         var tree = new Tree(inputName);
         var grouped = imageResult.Results.GroupBy(r => r.Label);
         foreach (var group in grouped)
@@ -161,7 +187,7 @@ public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
             var groupNode = tree.AddNode(group.Key);
             foreach (var match in group.ToList())
             {
-                groupNode.AddNode($"{match.Box.ToSize()} ({(match.Confidence*100).ToString("N2")}%)");
+                groupNode.AddNode($"{match.Box.ToSize()} ({(match.Confidence * 100).ToString("N2")}%)");
             }
         }
         return tree;
@@ -178,17 +204,18 @@ public class CensorCommand : AsyncCommand<CensorCommand.CensorCommandSettings> {
     // }
 
     static string CalculateMD5(byte[] model)
-{
-    using (var md5 = System.Security.Cryptography.MD5.Create())
     {
-        var hash = md5.ComputeHash(model);
-        return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        using (var md5 = System.Security.Cryptography.MD5.Create())
+        {
+            var hash = md5.ComputeHash(model);
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
     }
-}
 
 }
 
-public class CensoringSettings : CommandSettings {
+public class CensoringSettings : CommandSettings
+{
     [CommandOption("-m|--model-file")]
     public string? ModelFilePath { get; set; }
 
@@ -209,12 +236,12 @@ public class CensoringSettings : CommandSettings {
     [CommandOption("--no-transformers")]
     [Description("Disables the default results transformers. Censors the image exactly as it comes from the classifier.")]
     [DefaultValue(false)]
-    public bool NoTransformers {get;set;}
+    public bool NoTransformers { get; set; }
 
     [CommandOption("--optimization")]
     [Description("Override the default optimization mode.")]
     [DefaultValue(OptimizationMode.Normal)]
-    public OptimizationMode OptimizationMode {get;set;}
+    public OptimizationMode OptimizationMode { get; set; }
 }
 
 

--- a/src/CensorCore.Console/CensorCore.Console.csproj
+++ b/src/CensorCore.Console/CensorCore.Console.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsPublishable>true</IsPublishable>
     <EmbedModel></EmbedModel>

--- a/src/CensorCore.Console/CensorCore.Console.csproj
+++ b/src/CensorCore.Console/CensorCore.Console.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsPublishable>true</IsPublishable>
     <EmbedModel></EmbedModel>
@@ -25,8 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.43.0" />
-    <PackageReference Include="TextCopy" Version="6.1.0" />
+    <PackageReference Include="Spectre.Console" Version="0.50.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
+    <PackageReference Include="TextCopy" Version="6.2.1" />
   </ItemGroup>
 
 </Project>

--- a/src/CensorCore.Console/OverrideFileParser.cs
+++ b/src/CensorCore.Console/OverrideFileParser.cs
@@ -1,41 +1,50 @@
 using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
 using CensorCore.Censoring;
 
 namespace CensorCore.Console;
 
-public class OverrideFileParser : IResultParser {
+public class OverrideFileParser : IResultParser
+{
     private readonly FileInfo _file;
     private readonly ImageCensorOptions _defaults;
     internal Dictionary<string, List<string>>? _overrides;
 
-    public OverrideFileParser(string filePath) : this(filePath, null) {
+    public OverrideFileParser(string filePath) : this(filePath, null)
+    {
     }
 
-    public OverrideFileParser(string filePath, ImageCensorOptions? defaultOptions) {
+    public OverrideFileParser(string filePath, ImageCensorOptions? defaultOptions)
+    {
         this._file = new FileInfo(filePath);
         this._defaults = defaultOptions ?? new ImageCensorOptions("blur") { Level = 10 };
     }
 
-    public async Task<bool> Load() {
-        try {
-            if (_file.Exists) {
+    public async Task<bool> Load()
+    {
+        try
+        {
+            if (_file.Exists)
+            {
                 var json = await File.ReadAllTextAsync(_file.FullName);
                 var dict = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(json, SourceGenerationContext.Default.Dictionary);
-                if (dict != null && dict.Keys.Any()) {
+                if (dict != null && dict.Keys.Any())
+                {
                     _overrides = dict;
                     return true;
                 }
             }
             return false;
         }
-        catch {
+        catch
+        {
             return false;
         }
     }
 
-    public ImageCensorOptions? GetOptions(string label, ImageResult? image = null) {
-        if (_overrides != null && _overrides.TryGetValue(label, out var overrideResult)) {
+    public ImageCensorOptions? GetOptions(string label, ImageResult? image = null)
+    {
+        if (_overrides != null && _overrides.TryGetValue(label, out var overrideResult))
+        {
             return new ImageCensorOptions(overrideResult.First(), overrideResult.Count > 1 ? int.TryParse(overrideResult[1], out var oLevel) ? oLevel : 10 : 10);
         }
         return _defaults;

--- a/src/CensorCore.Console/Program.cs
+++ b/src/CensorCore.Console/Program.cs
@@ -2,7 +2,8 @@
 using Spectre.Console.Cli;
 
 var app = new CommandApp();
-app.Configure(c => {
+app.Configure(c =>
+{
     c.PropagateExceptions();
     c.AddCommand<CensorCommand>("censor-image");
 });

--- a/src/CensorCore.ModelLoader/CensorCore.ModelLoader.csproj
+++ b/src/CensorCore.ModelLoader/CensorCore.ModelLoader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>

--- a/src/CensorCore.ModelLoader/CensorCore.ModelLoader.csproj
+++ b/src/CensorCore.ModelLoader/CensorCore.ModelLoader.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.50.0" />
+    <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CensorCore.ModelLoader/CoreExtensions.cs
+++ b/src/CensorCore.ModelLoader/CoreExtensions.cs
@@ -1,7 +1,9 @@
 namespace CensorCore.ModelLoader;
 
-internal static class CoreExtensions {
-    internal static string Name(this string s) {
+internal static class CoreExtensions
+{
+    internal static string Name(this string s)
+    {
         return Path.GetFileNameWithoutExtension(s);
     }
 }

--- a/src/CensorCore.ModelLoader/ModelLoader.cs
+++ b/src/CensorCore.ModelLoader/ModelLoader.cs
@@ -2,7 +2,8 @@ using System.Reflection;
 
 namespace CensorCore.ModelLoader;
 
-public class ModelLoader {
+public class ModelLoader
+{
     private readonly List<string> _searchPaths;
     private readonly List<Assembly> _searchAssemblies;
     private readonly ModelLoaderOptions _options;
@@ -14,57 +15,73 @@ public class ModelLoader {
         this._options = opts;
     }
 
-    public async Task<byte[]?> GetModel(string? filePath = null) {
+    public async Task<byte[]?> GetModel(string? filePath = null)
+    {
         var local = await GetLocalModel(filePath);
-        if (local == null) {
+        if (local == null)
+        {
             var dl = await DownloadModel(true);
-            if (dl.HasValue) {
+            if (dl.HasValue)
+            {
                 local = dl.Value.ModelData;
             }
         }
         return local;
     }
 
-    public async Task<byte[]?> GetLocalModel(string? filePath) {
-        if (filePath != null && File.Exists(filePath) && Path.GetExtension(filePath) == ".onnx") {
+    public async Task<byte[]?> GetLocalModel(string? filePath)
+    {
+        if (filePath != null && File.Exists(filePath) && Path.GetExtension(filePath) == ".onnx")
+        {
             return File.ReadAllBytes(filePath);
         }
-        else if (GetModelInDirectory(filePath, _options) is var modelFile && modelFile != null) {
+        else if (GetModelInDirectory(filePath, _options) is var modelFile && modelFile != null)
+        {
             return File.ReadAllBytes(modelFile.FullName);
         }
-        else {
+        else
+        {
             //filePath is null or invalid, time to start fishing.
-            
+
             var local = _searchPaths.Select(p => GetModelInDirectory(p, _options)).FirstOrDefault(p => p != null);
-            if (local != null) {
+            if (local != null)
+            {
                 return await File.ReadAllBytesAsync(local.FullName);
             }
             //it's getting dire. Check for an embedded model.
             var embedded = GetModelResource(Assembly.GetEntryAssembly());
-            if (embedded != null) {
+            if (embedded != null)
+            {
                 return embedded;
             }
             return null;
         }
     }
 
-    public async Task<(string FileName, byte[] ModelData)?> DownloadModel(bool saveToSharedLocation = false) {
+    public async Task<(string FileName, byte[] ModelData)?> DownloadModel(bool saveToSharedLocation = false)
+    {
         var client = new RepositoryDownloadClient(_options.RepositorySlug);
         var model = await client.DownloadModel(_options.GetClassifier, _options.PreferBaseModel);
-        if (model != null && saveToSharedLocation) {
-            try {
+        if (model != null && saveToSharedLocation)
+        {
+            try
+            {
                 var tempPath = Path.Combine(Path.GetTempPath(), ".nudenet");
                 Directory.CreateDirectory(tempPath);
                 await File.WriteAllBytesAsync(Path.Combine(tempPath, model.Value.FileName), model.Value.ModelData);
-            } catch {
+            }
+            catch
+            {
                 //ignored
             }
         }
         return model;
     }
 
-    private FileInfo? GetModelInDirectory(string? directoryPath, ModelLoaderOptions _options) {
-        if (directoryPath != null && Directory.Exists(directoryPath) && Directory.GetFiles(directoryPath).Where(f => Path.GetExtension(f) == ".onnx") is var modelFiles && modelFiles.Any()) {
+    private FileInfo? GetModelInDirectory(string? directoryPath, ModelLoaderOptions _options)
+    {
+        if (directoryPath != null && Directory.Exists(directoryPath) && Directory.GetFiles(directoryPath).Where(f => Path.GetExtension(f) == ".onnx") is var modelFiles && modelFiles.Any())
+        {
             //there's *A* model file here, check if it's good.
             var candidate = _options.GetClassifier
                 ? modelFiles.FirstOrDefault(mf => mf.Name().StartsWith("classifier_"))
@@ -74,19 +91,23 @@ public class ModelLoader {
         return null;
     }
 
-    private static byte[]? GetModelResource(Assembly? assembly = null) {
+    private static byte[]? GetModelResource(Assembly? assembly = null)
+    {
 
         var entryAssembly = assembly ?? typeof(ModelLoader).Assembly;
         var model = entryAssembly.GetManifestResourceNames();
         //TODO: this doesn't match right
-        if (model != null && model.Any() && model.FirstOrDefault(r => r.EndsWith(".onnx")) is var modelResource && modelResource != null) {
+        if (model != null && model.Any() && model.FirstOrDefault(r => r.EndsWith(".onnx")) is var modelResource && modelResource != null)
+        {
             // Console.WriteLine($"reading stream from {modelResource}");
             using var resourceStream = entryAssembly.GetManifestResourceStream(modelResource);
-            if (resourceStream != null && resourceStream.CanRead) {
+            if (resourceStream != null && resourceStream.CanRead)
+            {
                 using var ms = new MemoryStream();
                 resourceStream.CopyTo(ms);
                 var modelBytes = ms.ToArray();
-                if (modelBytes != null && modelBytes.Length > 0) {
+                if (modelBytes != null && modelBytes.Length > 0)
+                {
                     return modelBytes;
                 }
             }

--- a/src/CensorCore.ModelLoader/ModelLoaderBuilder.cs
+++ b/src/CensorCore.ModelLoader/ModelLoaderBuilder.cs
@@ -2,7 +2,8 @@
 
 namespace CensorCore.ModelLoader;
 
-public class ModelLoaderBuilder {
+public class ModelLoaderBuilder
+{
     private readonly List<string> _searchPaths;
     private readonly List<Assembly> _assemblies;
     private readonly ModelLoaderOptions _opts;
@@ -14,41 +15,49 @@ public class ModelLoaderBuilder {
         this._opts = new ModelLoaderOptions();
     }
 
-    public ModelLoaderBuilder AddDefaultPaths() {
+    public ModelLoaderBuilder AddDefaultPaths()
+    {
         var tempDir = Path.Combine(Path.GetTempPath(), ".nudenet");
-        var paths = new[] { Environment.CurrentDirectory, AppContext.BaseDirectory, tempDir};
+        var paths = new[] { Environment.CurrentDirectory, AppContext.BaseDirectory, tempDir };
         _searchPaths.AddRange(paths);
         return this;
     }
 
-    public ModelLoaderBuilder AddSearchPath(string path) {
+    public ModelLoaderBuilder AddSearchPath(string path)
+    {
         _searchPaths.Add(path);
         return this;
     }
 
-    public ModelLoaderBuilder SearchAssembly(Assembly? assembly) {
-        if (assembly != null) {
+    public ModelLoaderBuilder SearchAssembly(Assembly? assembly)
+    {
+        if (assembly != null)
+        {
             _assemblies.Add(assembly);
         }
         return this;
     }
 
-    public ModelLoaderBuilder PreferBase(bool preferBaseModel = true) {
+    public ModelLoaderBuilder PreferBase(bool preferBaseModel = true)
+    {
         _opts.PreferBaseModel = preferBaseModel;
         return this;
     }
 
-    public ModelLoaderBuilder GetClassifier(bool preferClassifierModel = true) {
+    public ModelLoaderBuilder GetClassifier(bool preferClassifierModel = true)
+    {
         _opts.GetClassifier = preferClassifierModel;
         return this;
     }
 
-    public ModelLoaderBuilder UseAlternateRepository(string repoSlug) {
+    public ModelLoaderBuilder UseAlternateRepository(string repoSlug)
+    {
         _opts.RepositorySlug = repoSlug;
         return this;
     }
-    
-    public ModelLoader Build() {
+
+    public ModelLoader Build()
+    {
         return new ModelLoader(_searchPaths, _assemblies, _opts);
     }
 }

--- a/src/CensorCore.ModelLoader/ModelLoaderOptions.cs
+++ b/src/CensorCore.ModelLoader/ModelLoaderOptions.cs
@@ -1,7 +1,8 @@
 namespace CensorCore.ModelLoader;
 
-public class ModelLoaderOptions {
-    public bool PreferBaseModel {get;set;} = false;
-    public bool GetClassifier {get;set;} = false;
-    public string RepositorySlug {get;set;} = "notAI-tech/NudeNet";
+public class ModelLoaderOptions
+{
+    public bool PreferBaseModel { get; set; } = false;
+    public bool GetClassifier { get; set; } = false;
+    public string RepositorySlug { get; set; } = "notAI-tech/NudeNet";
 }

--- a/src/CensorCore.ModelLoader/RepositoryDownloadClient.cs
+++ b/src/CensorCore.ModelLoader/RepositoryDownloadClient.cs
@@ -1,53 +1,61 @@
 using Octokit;
 
-namespace CensorCore.ModelLoader
+namespace CensorCore.ModelLoader;
+
+public class RepositoryDownloadClient
 {
-    public class RepositoryDownloadClient
+    private readonly string _owner;
+    private readonly string _repo;
+
+    public RepositoryDownloadClient(string repoId)
     {
-        private readonly string _owner;
-        private readonly string _repo;
+        this._owner = repoId.Split("/").First();
+        this._repo = repoId.Split("/").Last();
+    }
 
-        public RepositoryDownloadClient(string repoId)
+    public async Task<(string FileName, byte[] ModelData)?> DownloadModel(bool getClassifier = false, bool preferBase = false)
+    {
+        var github = new GitHubClient(new ProductHeaderValue("CensorCore.ModelLoader"));
+        var releases = await github.Repository.Release.GetAll("notAI-tech", "NudeNet");
+        var checkpointRelease = releases.OrderByDescending(r => r.CreatedAt).FirstOrDefault(r => r.Assets.Any(a => a.Name.EndsWith(".onnx")));
+        if (checkpointRelease != null)
         {
-            this._owner = repoId.Split("/").First();
-            this._repo = repoId.Split("/").Last();
-        }
-
-        public async Task<(string FileName, byte[] ModelData)?> DownloadModel(bool getClassifier = false, bool preferBase = false) {
-            var github = new GitHubClient(new ProductHeaderValue("CensorCore.ModelLoader"));
-            var releases = await github.Repository.Release.GetAll("notAI-tech", "NudeNet");
-            var checkpointRelease = releases.OrderByDescending(r => r.CreatedAt).FirstOrDefault(r => r.Assets.Any(a => a.Name.EndsWith(".onnx")));
-            if (checkpointRelease != null) {
-                if (getClassifier) {
-                    var classifierRelease = checkpointRelease.Assets.FirstOrDefault(r => r.Name.Contains("classifier") && r.Name.EndsWith(".onnx"));
-                    if (classifierRelease == null) {
-                        throw new Exception("Could not locate detector asset in GitHub Releases!");
-                    }
-                    var baseAsset = await github.Repository.Release.GetAsset(this._owner, this._repo, classifierRelease.Id);
+            if (getClassifier)
+            {
+                var classifierRelease = checkpointRelease.Assets.FirstOrDefault(r => r.Name.Contains("classifier") && r.Name.EndsWith(".onnx"));
+                if (classifierRelease == null)
+                {
+                    throw new Exception("Could not locate detector asset in GitHub Releases!");
+                }
+                var baseAsset = await github.Repository.Release.GetAsset(this._owner, this._repo, classifierRelease.Id);
+                var download = await github.Connection.Get<byte[]>(new Uri(baseAsset.Url), new Dictionary<string, string>(), "application/octet-stream");
+                return (baseAsset.Name, download.Body);
+            }
+            else
+            {
+                var baseRelease = checkpointRelease.Assets.FirstOrDefault(r => r.IsDetector(preferBase));
+                if (baseRelease != null)
+                {
+                    var baseAsset = await github.Repository.Release.GetAsset(this._owner, this._repo, baseRelease.Id);
                     var download = await github.Connection.Get<byte[]>(new Uri(baseAsset.Url), new Dictionary<string, string>(), "application/octet-stream");
                     return (baseAsset.Name, download.Body);
-                } else {
-                    var baseRelease = checkpointRelease.Assets.FirstOrDefault(r => r.IsDetector(preferBase));
-                    if (baseRelease != null) {
-                        var baseAsset = await github.Repository.Release.GetAsset(this._owner, this._repo, baseRelease.Id);
-                        var download = await github.Connection.Get<byte[]>(new Uri(baseAsset.Url), new Dictionary<string, string>(), "application/octet-stream");
-                        return (baseAsset.Name, download.Body);
-                    }
                 }
-                return null;
             }
             return null;
         }
+        return null;
     }
+}
 
-    public static class AssetExtensions {
-        public static bool IsDetector(this ReleaseAsset asset, bool preferBase) {
-            var outcome = asset.Name.EndsWith(".onnx") &&
-                asset.Name.Contains("detector") &&
-                (preferBase 
-                    ? asset.Name.Contains("_base_") 
-                    : !asset.Name.Contains("_base"));
-            return outcome;
-        } 
+public static class AssetExtensions
+{
+    public static bool IsDetector(this ReleaseAsset asset, bool preferBase)
+    {
+        var outcome = asset.Name.EndsWith(".onnx") &&
+                      asset.Name.Contains("detector") &&
+                      (preferBase
+                          ? asset.Name.Contains("_base_")
+                          : !asset.Name.Contains("_base"));
+        return outcome;
     }
 }

--- a/src/CensorCore.Runtime/AIRuntime.cs
+++ b/src/CensorCore.Runtime/AIRuntime.cs
@@ -4,36 +4,47 @@ using Microsoft.ML.OnnxRuntime;
 namespace CensorCore.Runtime;
 public static class AIRuntime
 {
-    public static AIService CreateService(byte[] model, IImageHandler imageHandler, bool enableAcceleration = true) {
-            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            var isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-            if ((isWindows || isLinux) && enableAcceleration) {
-                InferenceSession? hwSession = null;
-                var deviceId = 0;
-                while (hwSession == null && deviceId < 2) {
-                    try {
-                        var hwOpts = new SessionOptions();
-                        if (isWindows) {
-                            hwOpts.AppendExecutionProvider_DML(deviceId);
-                        } else if (isLinux) {
-                            hwOpts.AppendExecutionProvider_CUDA(deviceId);
-                        } else if (isMac) {
-                            hwOpts.AppendExecutionProvider_CoreML();
-                        }
-                        hwSession = new InferenceSession(model, hwOpts);
-                        return new AIService(hwSession, imageHandler);
+    public static AIService CreateService(byte[] model, IImageHandler imageHandler, bool enableAcceleration = true)
+    {
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        var isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        if ((isWindows || isLinux) && enableAcceleration)
+        {
+            InferenceSession? hwSession = null;
+            var deviceId = 0;
+            while (hwSession == null && deviceId < 2)
+            {
+                try
+                {
+                    var hwOpts = new SessionOptions();
+                    if (isWindows)
+                    {
+                        hwOpts.AppendExecutionProvider_DML(deviceId);
                     }
-                    catch {
-                        deviceId++;
+                    else if (isLinux)
+                    {
+                        hwOpts.AppendExecutionProvider_CUDA(deviceId);
                     }
+                    else if (isMac)
+                    {
+                        hwOpts.AppendExecutionProvider_CoreML();
+                    }
+                    hwSession = new InferenceSession(model, hwOpts);
+                    return new AIService(hwSession, imageHandler);
                 }
-                Console.WriteLine("WARN: Failed to initialize hardware acceleration!");
+                catch
+                {
+                    deviceId++;
+                }
             }
-            var opts = new SessionOptions() {
-                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
-            };
-            var session = new InferenceSession(model, opts);
-            return new AIService(session, imageHandler);
+            Console.WriteLine("WARN: Failed to initialize hardware acceleration!");
         }
+        var opts = new SessionOptions()
+        {
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+        };
+        var session = new InferenceSession(model, opts);
+        return new AIService(session, imageHandler);
+    }
 }

--- a/src/CensorCore.Runtime/CensorCore.Runtime.csproj
+++ b/src/CensorCore.Runtime/CensorCore.Runtime.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Condition="'$(RuntimeIdentifier)' == 'win-x64'" Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.18.0" />
     <PackageReference Condition="'$(RuntimeIdentifier)' == 'linux-x64'" Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.18.0" />
-    <PackageReference Condition="'$(RuntimeIdentifier)' != 'win-x64' And '$(RuntimeIdentifier)' != 'linux-x64'" Include="Microsoft.ML.OnnxRuntime" Version="1.18.0" />
+    <PackageReference Condition="'$(RuntimeIdentifier)' != 'win-x64' And '$(RuntimeIdentifier)' != 'linux-x64'" Include="Microsoft.ML.OnnxRuntime" Version="1.21.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CensorCore.Runtime/CensorCore.Runtime.csproj
+++ b/src/CensorCore.Runtime/CensorCore.Runtime.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 
@@ -15,11 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.10.0" /> -->
-    <PackageReference Condition="'$(RuntimeIdentifier)' == 'win-x64'" Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.12.1" />
-    <PackageReference Condition="'$(RuntimeIdentifier)' == 'linux-x64'" Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.12.1" />
-    <PackageReference Condition="'$(RuntimeIdentifier)' != 'win-x64' And '$(RuntimeIdentifier)' != 'linux-x64'" Include="Microsoft.ML.OnnxRuntime" Version="1.12.1" />
-    
+    <PackageReference Condition="'$(RuntimeIdentifier)' == 'win-x64'" Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.18.0" />
+    <PackageReference Condition="'$(RuntimeIdentifier)' == 'linux-x64'" Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.18.0" />
+    <PackageReference Condition="'$(RuntimeIdentifier)' != 'win-x64' And '$(RuntimeIdentifier)' != 'linux-x64'" Include="Microsoft.ML.OnnxRuntime" Version="1.18.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CensorCore.Server/CensorCore.Server.csproj
+++ b/src/CensorCore.Server/CensorCore.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsPublishable>true</IsPublishable>
   </PropertyGroup>

--- a/src/CensorCore.Server/CensorCore.Server.csproj
+++ b/src/CensorCore.Server/CensorCore.Server.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CensorCore.Server/Program.cs
+++ b/src/CensorCore.Server/Program.cs
@@ -19,17 +19,20 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddSingleton<IImageHandler>(p => new ImageSharpHandler());
-builder.Services.AddSingleton<ModelLoader>(p => {
+builder.Services.AddSingleton<ModelLoader>(p =>
+{
     return new ModelLoaderBuilder()
         .AddDefaultPaths()
         // .AddSearchPath(config)
         .SearchAssembly(System.Reflection.Assembly.GetEntryAssembly())
         .Build();
 });
-builder.Services.AddSingleton<AIService>(p => {
+builder.Services.AddSingleton<AIService>(p =>
+{
     // var loader = p.GetRequiredService<ModelLoader>();
     // var model = await loader.GetModel();
-    if (model == null) {
+    if (model == null)
+    {
         throw new InvalidOperationException("Could not load model from any available source!");
     }
     return CensorCore.Runtime.AIRuntime.CreateService(model, p.GetRequiredService<IImageHandler>());

--- a/src/CensorCore.Shared/BoundingBox.cs
+++ b/src/CensorCore.Shared/BoundingBox.cs
@@ -6,8 +6,8 @@ public class BoundingBox
     {
         this.X = x;
         this.Y = y;
-        this.Width = (int)Math.Ceiling(endX-x);
-        this.Height = (int)Math.Ceiling(endY-y);
+        this.Width = (int)Math.Ceiling(endX - x);
+        this.Height = (int)Math.Ceiling(endY - y);
     }
 
     public float X { get; set; }
@@ -15,7 +15,8 @@ public class BoundingBox
     public int Height { get; set; }
     public int Width { get; set; }
 
-    public string ToSize() {
+    public string ToSize()
+    {
         return $"{Width}x{Height}";
     }
 }

--- a/src/CensorCore.Shared/CensorCore.Shared.csproj
+++ b/src/CensorCore.Shared/CensorCore.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>CensorCore</RootNamespace>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>

--- a/src/CensorCore.Shared/CensorCore.Shared.csproj
+++ b/src/CensorCore.Shared/CensorCore.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>CensorCore</RootNamespace>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>

--- a/src/CensorCore.Shared/CensoredImage.cs
+++ b/src/CensorCore.Shared/CensoredImage.cs
@@ -1,17 +1,16 @@
-namespace CensorCore
+namespace CensorCore;
+
+public class CensoredImage
 {
-    public class CensoredImage
+    public byte[] ImageContents { get; }
+
+    public CensoredImage(byte[] imageContents, string mimeType, string? imageDataUrl)
     {
-        public byte[] ImageContents {get;}
-
-        public CensoredImage(byte[] imageContents, string mimeType, string? imageDataUrl)
-        {
-            ImageContents = imageContents;
-            MimeType = mimeType;
-            ImageDataUrl = imageDataUrl ?? $"data:{mimeType};base64,{Convert.ToBase64String(imageContents, Base64FormattingOptions.InsertLineBreaks)}";
-        }
-
-        public string MimeType {get;}
-        public string ImageDataUrl {get;}
+        ImageContents = imageContents;
+        MimeType = mimeType;
+        ImageDataUrl = imageDataUrl ?? $"data:{mimeType};base64,{Convert.ToBase64String(imageContents, Base64FormattingOptions.InsertLineBreaks)}";
     }
+
+    public string MimeType { get; }
+    public string ImageDataUrl { get; }
 }

--- a/src/CensorCore.Shared/Classification.cs
+++ b/src/CensorCore.Shared/Classification.cs
@@ -1,36 +1,36 @@
-namespace CensorCore
+namespace CensorCore;
+
+public class Classification
 {
-    public class Classification {
-        public BoundingBox Box {get;set;}
+    public BoundingBox Box { get; set; }
 
-        public Classification(BoundingBox box, float confidence, string label)
-        {
-            Box = box;
-            Confidence = confidence;
-            Label = label;
-        }
-
-        public float Confidence {get;set;}
-        public string Label {get;set;}
-
-        /// <summary>
-        /// Offset angle for any reference points this classification is based on. 
-        /// This will only be set when the classification has been transformed from the original match. 
-        /// This will (usually) be set to the angle between any existing reference points from the original match.
-        /// </summary>
-        /// <value>The angle in degrees of the underlying reference points (if present).</value>
-        public float? SourceAngle {get;set;} = null;
-
-        /// <summary>
-        /// Indicates if this classification's bounding box is a "virtual" match.
-        /// If this is true, the box should only be considered a valid match if it
-        /// has also had relevant transforms applied.
-        /// </summary>
-        /// <remarks>
-        /// The most notable effect of this flag being true is that providers that
-        /// don't support rotation will likely ignore the match entirely.
-        /// </remarks>
-        /// <value>True if the bounding box is virtual, otherwise false.</value>
-        public bool VirtualBox {get;set;} = false;
+    public Classification(BoundingBox box, float confidence, string label)
+    {
+        Box = box;
+        Confidence = confidence;
+        Label = label;
     }
+
+    public float Confidence { get; set; }
+    public string Label { get; set; }
+
+    /// <summary>
+    /// Offset angle for any reference points this classification is based on. 
+    /// This will only be set when the classification has been transformed from the original match. 
+    /// This will (usually) be set to the angle between any existing reference points from the original match.
+    /// </summary>
+    /// <value>The angle in degrees of the underlying reference points (if present).</value>
+    public float? SourceAngle { get; set; } = null;
+
+    /// <summary>
+    /// Indicates if this classification's bounding box is a "virtual" match.
+    /// If this is true, the box should only be considered a valid match if it
+    /// has also had relevant transforms applied.
+    /// </summary>
+    /// <remarks>
+    /// The most notable effect of this flag being true is that providers that
+    /// don't support rotation will likely ignore the match entirely.
+    /// </remarks>
+    /// <value>True if the bounding box is virtual, otherwise false.</value>
+    public bool VirtualBox { get; set; } = false;
 }

--- a/src/CensorCore.Tests/CensorCore.Tests.csproj
+++ b/src/CensorCore.Tests/CensorCore.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CensorCore.Tests/CensorCore.Tests.csproj
+++ b/src/CensorCore.Tests/CensorCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/CensorCore.Tests/IntersectionTransformerTests.cs
+++ b/src/CensorCore.Tests/IntersectionTransformerTests.cs
@@ -1,15 +1,15 @@
-using CensorCore;
 using CensorCore.Censoring;
 using Xunit;
 
 namespace CensorCore.Tests;
 
-public class IntersectionTransformerTests {
+public class IntersectionTransformerTests
+{
     [Fact]
     public void SkipsSingleMatches()
     {
         var merger = new IntersectingMatchMerger();
-        var classifications = new[] { new Classification(new BoundingBox(5,5, 10, 10), 1, "_FACE_F") };
+        var classifications = new[] { new Classification(new BoundingBox(5, 5, 10, 10), 1, "_FACE_F") };
         var transformed = merger.TransformResults(classifications, null).ToList();
 
         Assert.Single(transformed);
@@ -18,9 +18,10 @@ public class IntersectionTransformerTests {
     }
 
     [Fact]
-    public void ReturnsAllDistinct() {
+    public void ReturnsAllDistinct()
+    {
         var merger = new IntersectingMatchMerger();
-        var classifications = new[] { 
+        var classifications = new[] {
             new Classification(new BoundingBox(5,5, 10, 10), 1, "_FACE_F"),
             new Classification(new BoundingBox(50, 50, 55, 65), 1, "_FACE_F") };
         var transformed = merger.TransformResults(classifications, null).ToList();
@@ -31,11 +32,12 @@ public class IntersectionTransformerTests {
     }
 
     [Fact]
-    public void DoesNotMergeDifferentClasses() {
+    public void DoesNotMergeDifferentClasses()
+    {
         var merger = new IntersectingMatchMerger();
-        var classifications = new[] { 
+        var classifications = new[] {
             new Classification(new BoundingBox(5,5, 20, 20), 1, "_FACE_F"),
-            new Classification(new BoundingBox(10,10, 30, 30), 1, "_FACE_M") 
+            new Classification(new BoundingBox(10,10, 30, 30), 1, "_FACE_M")
         };
         var transformed = merger.TransformResults(classifications, null).ToList();
 
@@ -45,11 +47,12 @@ public class IntersectionTransformerTests {
     }
 
     [Fact]
-    public void MergesOverlapping() {
+    public void MergesOverlapping()
+    {
         var merger = new IntersectingMatchMerger();
-        var classifications = new[] { 
+        var classifications = new[] {
             new Classification(new BoundingBox(5,5, 20, 15), 1, "_FACE_F"),
-            new Classification(new BoundingBox(10,10, 30, 25), 1, "_FACE_F") 
+            new Classification(new BoundingBox(10,10, 30, 25), 1, "_FACE_F")
         };
         var transformed = merger.TransformResults(classifications, null).ToList();
 
@@ -59,12 +62,13 @@ public class IntersectionTransformerTests {
     }
 
     [Fact]
-    public void MergesMultipleOverlapping() {
+    public void MergesMultipleOverlapping()
+    {
         var merger = new IntersectingMatchMerger();
-        var classifications = new[] { 
+        var classifications = new[] {
             new Classification(new BoundingBox(5,5, 20, 15), 1, "_FACE_F"),
             new Classification(new BoundingBox(10,10, 30, 25), 1, "_FACE_F"),
-            new Classification(new BoundingBox(5,15, 30, 25), 1, "_FACE_F") 
+            new Classification(new BoundingBox(5,15, 30, 25), 1, "_FACE_F")
         };
         var transformed = merger.TransformResults(classifications, null).ToList();
 
@@ -74,12 +78,13 @@ public class IntersectionTransformerTests {
     }
 
     [Fact]
-    public void ClaimsHighestConfidence() {
+    public void ClaimsHighestConfidence()
+    {
         var merger = new IntersectingMatchMerger();
-        var classifications = new[] { 
+        var classifications = new[] {
             new Classification(new BoundingBox(5,5, 20, 15), 0.5F, "_FACE_F"),
             new Classification(new BoundingBox(10,10, 30, 25), 0.75F, "_FACE_F") ,
-            new Classification(new BoundingBox(5,15, 30, 25), 1F, "_FACE_F") 
+            new Classification(new BoundingBox(5,15, 30, 25), 1F, "_FACE_F")
         };
         var transformed = merger.TransformResults(classifications, null).ToList();
 
@@ -89,12 +94,13 @@ public class IntersectionTransformerTests {
     }
 
     [Fact]
-    public void IgnoresLowConfidenceExtras() {
+    public void IgnoresLowConfidenceExtras()
+    {
         var merger = new IntersectingMatchMerger();
-        var classifications = new[] { 
+        var classifications = new[] {
             new Classification(new BoundingBox(5,5, 20, 15), 0.85F, "_FACE_F"),
             new Classification(new BoundingBox(10,10, 30, 25), 1F, "_FACE_F") ,
-            new Classification(new BoundingBox(10,10, 35, 35), 0.5F, "_FACE_F") 
+            new Classification(new BoundingBox(10,10, 35, 35), 0.5F, "_FACE_F")
         };
         var transformed = merger.TransformResults(classifications, null).ToList();
 

--- a/src/CensorCore.Web/CensorCore.Web.csproj
+++ b/src/CensorCore.Web/CensorCore.Web.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
@@ -21,7 +21,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/CensorCore.Web/CensorCore.Web.csproj
+++ b/src/CensorCore.Web/CensorCore.Web.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>

--- a/src/CensorCore.Web/CensorImageRequestBody.cs
+++ b/src/CensorCore.Web/CensorImageRequestBody.cs
@@ -2,8 +2,9 @@ using CensorCore.Censoring;
 
 namespace CensorCore.Web;
 
-public class CensorImageRequestBody {
-    public string? ImageUrl {get;set;}
-    public string? ImageDataUrl {get;set;}
-    public Dictionary<string, ImageCensorOptions> CensorOptions {get;set;} = new Dictionary<string, ImageCensorOptions>();
+public class CensorImageRequestBody
+{
+    public string? ImageUrl { get; set; }
+    public string? ImageDataUrl { get; set; }
+    public Dictionary<string, ImageCensorOptions> CensorOptions { get; set; } = new Dictionary<string, ImageCensorOptions>();
 }

--- a/src/CensorCore.Web/CensoringController.cs
+++ b/src/CensorCore.Web/CensoringController.cs
@@ -19,8 +19,10 @@ public class CensoringController : ControllerBase
 
     [HttpGet("info")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public IActionResult GetInfo([FromServices]IImageHandler imageHandler, [FromServices]IEnumerable<CensorCore.Censoring.ICensorTypeProvider> types, [FromServices]GlobalCensorOptions? options = null) {
-        return Ok(new {
+    public IActionResult GetInfo([FromServices] IImageHandler imageHandler, [FromServices] IEnumerable<CensorCore.Censoring.ICensorTypeProvider> types, [FromServices] GlobalCensorOptions? options = null)
+    {
+        return Ok(new
+        {
             version = CoreManager.GetCoreVersion(),
             imageHandler = imageHandler.GetType().Name,
             provider = _censor.GetType().Name,
@@ -35,24 +37,33 @@ public class CensoringController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
-    public async Task<ActionResult<CensoredImage>> CensorImage([FromBody]CensorImageRequestBody requestBody, [FromQuery] bool returnEncoded = false) {
+    public async Task<ActionResult<CensoredImage>> CensorImage([FromBody] CensorImageRequestBody requestBody, [FromQuery] bool returnEncoded = false)
+    {
         var imageUrl = requestBody.ImageDataUrl ?? requestBody.ImageUrl;
-        if (!string.IsNullOrWhiteSpace(imageUrl)) {
+        if (!string.IsNullOrWhiteSpace(imageUrl))
+        {
             var result = await this._ai.RunModel(imageUrl);
             IResultParser? parser = null;
-            if (result != null) {
-                if (requestBody.CensorOptions != null && requestBody.CensorOptions.Any()) {
+            if (result != null)
+            {
+                if (requestBody.CensorOptions != null && requestBody.CensorOptions.Any())
+                {
                     parser = new StaticResultsParser(requestBody.CensorOptions);
                 }
                 var censored = await this._censor.CensorImage(result, parser);
-                if (returnEncoded) {
-                    return Ok(new { imageUrl = censored.ImageDataUrl, imageType = censored.MimeType});
+                if (returnEncoded)
+                {
+                    return Ok(new { imageUrl = censored.ImageDataUrl, imageType = censored.MimeType });
                 }
                 return File(censored.ImageContents, censored.MimeType);
-            } else {
+            }
+            else
+            {
                 return UnprocessableEntity();
             }
-        } else {
+        }
+        else
+        {
             return BadRequest();
         }
     }
@@ -61,11 +72,15 @@ public class CensoringController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
-    public async Task<IActionResult> GetCensoredImage([FromQuery] string url) {
-        if (!string.IsNullOrWhiteSpace(url)) {
+    public async Task<IActionResult> GetCensoredImage([FromQuery] string url)
+    {
+        if (!string.IsNullOrWhiteSpace(url))
+        {
             var result = await this._ai.RunModel(url);
-            if (result != null) {
-                var defaults = new Dictionary<string, ImageCensorOptions> {
+            if (result != null)
+            {
+                var defaults = new Dictionary<string, ImageCensorOptions>
+                {
                     ["EXPOSED_BREAST_F"] = new ImageCensorOptions("pixelate") { Level = 10 },
                     ["FACE_F"] = new ImageCensorOptions("blur") { Level = 10 },
                     ["EXPOSED_GENITALIA_F"] = new ImageCensorOptions("blackbars") { Level = 15 },
@@ -73,10 +88,14 @@ public class CensoringController : ControllerBase
                 };
                 var censored = await this._censor.CensorImage(result, new StaticResultsParser(defaults));
                 return File(censored.ImageContents, censored.MimeType);
-            } else {
+            }
+            else
+            {
                 return UnprocessableEntity();
             }
-        } else {
+        }
+        else
+        {
             return BadRequest();
         }
     }

--- a/src/CensorCore.Web/CoreManager.cs
+++ b/src/CensorCore.Web/CoreManager.cs
@@ -1,30 +1,36 @@
-using System.Diagnostics;
 using System.Reflection;
 
-namespace CensorCore.Web
-{
-    public static class CoreManager
-    {
-        public static string GetCoreVersion(bool preferType = true) {
-            var assembly = preferType ? typeof(AIService).Assembly : Assembly.GetExecutingAssembly();
-            var version = GetProductVersion(assembly);
-            if (!string.IsNullOrWhiteSpace(version)) {
-                return $"v{version}";
-            } else {
-                return "v0.0.0";
-            }
-        }
+namespace CensorCore.Web;
 
-        private static string? GetProductVersion(Assembly assembly) {
-            try {
+public static class CoreManager
+{
+    public static string GetCoreVersion(bool preferType = true)
+    {
+        var assembly = preferType ? typeof(AIService).Assembly : Assembly.GetExecutingAssembly();
+        var version = GetProductVersion(assembly);
+        if (!string.IsNullOrWhiteSpace(version))
+        {
+            return $"v{version}";
+        }
+        else
+        {
+            return "v0.0.0";
+        }
+    }
+
+    private static string? GetProductVersion(Assembly assembly)
+    {
+        try
+        {
             object[] attributes = assembly
-            .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
-        return attributes.Length == 0 ?
-            null :
-            ((AssemblyInformationalVersionAttribute)attributes[0]).InformationalVersion;
-            } catch {
-                return null;
-            }
+                .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
+            return attributes.Length == 0 ?
+                null :
+                ((AssemblyInformationalVersionAttribute)attributes[0]).InformationalVersion;
+        }
+        catch
+        {
+            return null;
         }
     }
 }

--- a/src/CensorCore.Web/ServiceExtensions.cs
+++ b/src/CensorCore.Web/ServiceExtensions.cs
@@ -1,11 +1,11 @@
 using Microsoft.Extensions.DependencyInjection;
 
-namespace CensorCore.Web
+namespace CensorCore.Web;
+
+public static class ServiceExtensions
 {
-    public static class ServiceExtensions
+    public static IMvcBuilder AddCensorCore(this IMvcBuilder mvc)
     {
-        public static IMvcBuilder AddCensorCore(this IMvcBuilder mvc) {
-            return mvc.AddApplicationPart(typeof(CensoringController).Assembly);
-        }
+        return mvc.AddApplicationPart(typeof(CensoringController).Assembly);
     }
 }

--- a/src/CensorCore/AIService.cs
+++ b/src/CensorCore/AIService.cs
@@ -1,207 +1,238 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.InteropServices;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 
-namespace CensorCore
-{
-    public interface IAIService<TMatch>{
-        bool Verbose { get; set; }
-        SessionOptions? Options { get; }
+namespace CensorCore;
 
-        Task<ImageResult<TMatch>?> RunModel(byte[] data, MatchOptions? options = null);
-        Task<ImageResult<TMatch>?> RunModel(string url, MatchOptions? options = null);
+public interface IAIService<TMatch>
+{
+    bool Verbose { get; set; }
+    SessionOptions? Options { get; }
+
+    Task<ImageResult<TMatch>?> RunModel(byte[] data, MatchOptions? options = null);
+    Task<ImageResult<TMatch>?> RunModel(string url, MatchOptions? options = null);
+}
+
+/// <summary>
+/// Main service type for interacting with the AI model. Responsible for setting up, configurating and executing the image classifier.
+/// </summary>
+/// <remarks>
+/// This service does not perform any censoring on the image.
+/// </remarks>
+public class AIService
+{
+    public static readonly string[] ClassList = new[] { "EXPOSED_ANUS", "EXPOSED_ARMPITS", "COVERED_BELLY", "EXPOSED_BELLY", "COVERED_BUTTOCKS", "EXPOSED_BUTTOCKS", "FACE_F", "FACE_M", "COVERED_FEET", "EXPOSED_FEET", "COVERED_BREAST_F", "EXPOSED_BREAST_F", "COVERED_GENITALIA_F", "EXPOSED_GENITALIA_F", "EXPOSED_BREAST_M", "EXPOSED_GENITALIA_M" };
+    private readonly InferenceSession _session;
+    private readonly IImageHandler _imageHandler;
+    public bool Verbose { get; set; } = false;
+    public bool SkipGifs { get; set; } = false;
+
+    private void Log(string message)
+    {
+        if (Verbose)
+        {
+            Console.WriteLine(message);
+        }
     }
 
-    /// <summary>
-    /// Main service type for interacting with the AI model. Responsible for setting up, configurating and executing the image classifier.
-    /// </summary>
-    /// <remarks>
-    /// This service does not perform any censoring on the image.
-    /// </remarks>
-    public class AIService {
-        public static readonly string[] ClassList = new[] { "EXPOSED_ANUS", "EXPOSED_ARMPITS", "COVERED_BELLY", "EXPOSED_BELLY", "COVERED_BUTTOCKS", "EXPOSED_BUTTOCKS", "FACE_F", "FACE_M", "COVERED_FEET", "EXPOSED_FEET", "COVERED_BREAST_F", "EXPOSED_BREAST_F", "COVERED_GENITALIA_F", "EXPOSED_GENITALIA_F", "EXPOSED_BREAST_M", "EXPOSED_GENITALIA_M" };
-        private readonly InferenceSession _session;
-        private readonly IImageHandler _imageHandler;
-        public bool Verbose { get; set; } = false;
-        public bool SkipGifs { get; set; } = false;
+    public SessionOptions Options => new SessionOptions()
+    {
+        GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+    };
 
-        private void Log(string message) {
-            if (Verbose) {
-                Console.WriteLine(message);
-            }
-        }
-
-        public SessionOptions Options => new SessionOptions() {
+    public static async Task<AIService> CreateFromFileAsync(string modelPath, IImageHandler imageHandler)
+    {
+        var opts = new SessionOptions()
+        {
             GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
         };
-
-        public static async Task<AIService> CreateFromFileAsync(string modelPath, IImageHandler imageHandler) {
-            var opts = new SessionOptions() {
-                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
-            };
-            return await Task.Run(() =>
-            {
-                var session = new InferenceSession(modelPath, opts);
-                return new AIService(session, imageHandler);
-            });
-        }
-
-        public static AIService Create(byte[] model, IImageHandler imageHandler, bool enableAcceleration = true) {
-            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            if (isWindows && enableAcceleration) {
-                InferenceSession? hwSession = null;
-                var deviceId = 0;
-                while (hwSession == null && deviceId < 2) {
-                    try {
-                        var hwOpts = new SessionOptions() {
-
-                        };
-                        hwOpts.AppendExecutionProvider_DML(deviceId);
-                        hwSession = new InferenceSession(model, hwOpts);
-                        return new AIService(hwSession, imageHandler);
-                    }
-                    catch {
-                        deviceId++;
-                    }
-                }
-                Console.WriteLine("WARN: Failed to initialize hardware acceleration!");
-            }
-            var opts = new SessionOptions() {
-                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
-            };
-            var session = new InferenceSession(model, opts);
+        return await Task.Run(() =>
+        {
+            var session = new InferenceSession(modelPath, opts);
             return new AIService(session, imageHandler);
-        }
-        public static AIService CreateFromFile(string modelPath, IImageHandler imageHandler) {
-            return AIService.Create(File.ReadAllBytes(modelPath), imageHandler);
-        }
+        });
+    }
 
-        public AIService(byte[] modelContents, IImageHandler imageHandler) {
-            this._session = new InferenceSession(modelContents, Options);
-            this._imageHandler = imageHandler;
-        }
+    public static AIService Create(byte[] model, IImageHandler imageHandler, bool enableAcceleration = true)
+    {
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        if (isWindows && enableAcceleration)
+        {
+            InferenceSession? hwSession = null;
+            var deviceId = 0;
+            while (hwSession == null && deviceId < 2)
+            {
+                try
+                {
+                    var hwOpts = new SessionOptions()
+                    {
 
-        public AIService(InferenceSession session, IImageHandler imageHandler) {
-            this._session = session;
-            this._imageHandler = imageHandler;
-        }
-
-        public async Task<ImageResult?> RunModel<TTensor>(byte[] data, TensorLoadOptions<TTensor> loadOptions, MatchOptions? options = null) {
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Start();
-            var imageData = await this._imageHandler.LoadImageData(data);
-            if (SkipGifs && imageData.Format is SixLabors.ImageSharp.Formats.Gif.GifFormat) {
-                return null;
-            }
-            timer.Stop();
-            Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
-            var result = await RunModelForImage<TTensor>(imageData, options, loadOptions);
-            if (result != null && result.Session != null) {
-                result.Session.ImageLoadTime = timer.Elapsed;
-            }
-            return result;
-        }
-
-        public async Task<ImageResult?> RunModel(byte[] data, MatchOptions? options = null) {
-            return await RunModel<float>(data, new NudeNetLoadOptions(), options);
-        }
-
-        public async Task<ImageResult?> RunModel(string url, MatchOptions? options = null) {
-            return await RunModel<float>(url, new NudeNetLoadOptions(), options);
-        }
-
-        public async Task<ImageResult?> RunModel<TTensor>(string url, TensorLoadOptions<TTensor> loadOptions, MatchOptions? options = null) {
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Start();
-            var imageData = await this._imageHandler.LoadImage(url);
-            if (SkipGifs && imageData.Format is SixLabors.ImageSharp.Formats.Gif.GifFormat) {
-                return null;
-            }
-            timer.Stop();
-            Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
-            var result = await RunModelForImage<TTensor>(imageData, options, loadOptions);
-            if (result != null && result.Session != null) {
-                result.Session.ImageLoadTime = timer.Elapsed;
-            }
-            return result;
-        }
-
-        private async Task<ImageResult?> RunModelForImage<TTensor>(ImageData imageData, MatchOptions? options, TensorLoadOptions<TTensor> loadOptions) {
-            options ??= MatchOptions.GetDefault();
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Restart();
-            // var modelInput = await this._imageHandler.LoadToTensor(imageData);
-            var modelInput = await this._imageHandler.LoadToTensor<TTensor>(imageData, loadOptions);
-            timer.Stop();
-            var tensorLoadTime = timer.Elapsed;
-            Log($"Loaded tensor data in {timer.Elapsed.TotalSeconds}s");
-            timer.Restart();
-            var feeds = GetFeeds(modelInput).ToList();
-            var output = this._session.Run(feeds);
-            var runTime = timer.Elapsed;
-            Log($"Finished model in {timer.Elapsed.TotalSeconds}s");
-            timer.Restart();
-            var classifications = this.GetResults(imageData, output.ToList(), options).ToList();
-            var modelName = string.IsNullOrWhiteSpace(this._session.ModelMetadata.Description)
-                ? this._session.ModelMetadata.GraphName
-                : this._session.ModelMetadata.Description;
-            var sessionMeta = new SessionMetadata(modelName, runTime) {
-                TensorLoadTime = tensorLoadTime
-            };
-            var result = new ImageResult(imageData, classifications) {
-                Session = sessionMeta
-            };
-            Log($"Built results in {timer.Elapsed.TotalSeconds}s");
-            timer.Reset();
-            return result;
-        }
-
-        private IEnumerable<NamedOnnxValue> GetFeeds<TTensor>(InputImage<TTensor> input) {
-            return this._session.InputMetadata.Select(im => NamedOnnxValue.CreateFromTensor<TTensor>(im.Key, input.Tensor));
-        }
-
-        private IEnumerable<Classification> GetResults(ImageData imgData, List<DisposableNamedOnnxValue> tensorOutput, MatchOptions matchOptions) {
-            // var boxOutput = tensorOutput.First(to => to.ElementType == TensorElementType.Float && to.);
-            // var scoreOutput = tensorOutput.First(to => to.Name == "output2");
-            var labelOutput = tensorOutput.First(to => to.ElementType == TensorElementType.Int32); //output3
-
-            var floatTensors = tensorOutput.Where(to => to.ElementType == TensorElementType.Float).Select(to => to.AsTensor<float>()).ToList();
-            var rawScores = floatTensors.First(ft => ft.Length < 1000);
-            var rawBoxes = floatTensors.First(ft => ft.Length > 1000);
-            var rawLabels = labelOutput.AsTensor<int>();
-
-            var length = rawLabels.Length;
-            if (rawLabels.Last() == -1) {
-                var validLabels = rawLabels.TakeWhile(l => l != -1).ToList();
-                length = validLabels.Count;
-            }
-
-            var results = new List<Classification>();
-            var boxes = rawBoxes.Chunk(4).ToList();
-
-            for (int i = 0; i < length; i++) {
-                var confidence = rawScores.ElementAtOrDefault(i);
-                string? className = null;
-                try {
-                    var classNameIndex = rawLabels.ElementAt(i);
-                    className = ClassList[classNameIndex];
-                } catch {
-                    //ignored since it's clearly fucked
+                    };
+                    hwOpts.AppendExecutionProvider_DML(deviceId);
+                    hwSession = new InferenceSession(model, hwOpts);
+                    return new AIService(hwSession, imageHandler);
                 }
-                if (confidence > 0 && !string.IsNullOrWhiteSpace(className) && boxes.Count > i) {
-                    if (confidence >= matchOptions.GetScoreForClass(className)) {
-                        var box = boxes.ElementAt(i).ToBox(imgData.ScaleFactor, imgData.SampleOffset);
-                        results.Add(new Classification(box, confidence, className));
-                        // yield return new Classification(box, confidence, className);
-                    }
+                catch
+                {
+                    deviceId++;
                 }
             }
-            return results;
+            Console.WriteLine("WARN: Failed to initialize hardware acceleration!");
         }
+        var opts = new SessionOptions()
+        {
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+        };
+        var session = new InferenceSession(model, opts);
+        return new AIService(session, imageHandler);
+    }
+    public static AIService CreateFromFile(string modelPath, IImageHandler imageHandler)
+    {
+        return AIService.Create(File.ReadAllBytes(modelPath), imageHandler);
+    }
+
+    public AIService(byte[] modelContents, IImageHandler imageHandler)
+    {
+        this._session = new InferenceSession(modelContents, Options);
+        this._imageHandler = imageHandler;
+    }
+
+    public AIService(InferenceSession session, IImageHandler imageHandler)
+    {
+        this._session = session;
+        this._imageHandler = imageHandler;
+    }
+
+    public async Task<ImageResult?> RunModel<TTensor>(byte[] data, TensorLoadOptions<TTensor> loadOptions, MatchOptions? options = null)
+    {
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Start();
+        var imageData = await this._imageHandler.LoadImageData(data);
+        if (SkipGifs && imageData.Format is SixLabors.ImageSharp.Formats.Gif.GifFormat)
+        {
+            return null;
+        }
+        timer.Stop();
+        Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
+        var result = await RunModelForImage<TTensor>(imageData, options, loadOptions);
+        if (result != null && result.Session != null)
+        {
+            result.Session.ImageLoadTime = timer.Elapsed;
+        }
+        return result;
+    }
+
+    public async Task<ImageResult?> RunModel(byte[] data, MatchOptions? options = null)
+    {
+        return await RunModel<float>(data, new NudeNetLoadOptions(), options);
+    }
+
+    public async Task<ImageResult?> RunModel(string url, MatchOptions? options = null)
+    {
+        return await RunModel<float>(url, new NudeNetLoadOptions(), options);
+    }
+
+    public async Task<ImageResult?> RunModel<TTensor>(string url, TensorLoadOptions<TTensor> loadOptions, MatchOptions? options = null)
+    {
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Start();
+        var imageData = await this._imageHandler.LoadImage(url);
+        if (SkipGifs && imageData.Format is SixLabors.ImageSharp.Formats.Gif.GifFormat)
+        {
+            return null;
+        }
+        timer.Stop();
+        Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
+        var result = await RunModelForImage<TTensor>(imageData, options, loadOptions);
+        if (result != null && result.Session != null)
+        {
+            result.Session.ImageLoadTime = timer.Elapsed;
+        }
+        return result;
+    }
+
+    private async Task<ImageResult?> RunModelForImage<TTensor>(ImageData imageData, MatchOptions? options, TensorLoadOptions<TTensor> loadOptions)
+    {
+        options ??= MatchOptions.GetDefault();
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Restart();
+        // var modelInput = await this._imageHandler.LoadToTensor(imageData);
+        var modelInput = await this._imageHandler.LoadToTensor<TTensor>(imageData, loadOptions);
+        timer.Stop();
+        var tensorLoadTime = timer.Elapsed;
+        Log($"Loaded tensor data in {timer.Elapsed.TotalSeconds}s");
+        timer.Restart();
+        var feeds = GetFeeds(modelInput).ToList();
+        var output = this._session.Run(feeds);
+        var runTime = timer.Elapsed;
+        Log($"Finished model in {timer.Elapsed.TotalSeconds}s");
+        timer.Restart();
+        var classifications = this.GetResults(imageData, output.ToList(), options).ToList();
+        var modelName = string.IsNullOrWhiteSpace(this._session.ModelMetadata.Description)
+            ? this._session.ModelMetadata.GraphName
+            : this._session.ModelMetadata.Description;
+        var sessionMeta = new SessionMetadata(modelName, runTime)
+        {
+            TensorLoadTime = tensorLoadTime
+        };
+        var result = new ImageResult(imageData, classifications)
+        {
+            Session = sessionMeta
+        };
+        Log($"Built results in {timer.Elapsed.TotalSeconds}s");
+        timer.Reset();
+        return result;
+    }
+
+    private IEnumerable<NamedOnnxValue> GetFeeds<TTensor>(InputImage<TTensor> input)
+    {
+        return this._session.InputMetadata.Select(im => NamedOnnxValue.CreateFromTensor<TTensor>(im.Key, input.Tensor));
+    }
+
+    private IEnumerable<Classification> GetResults(ImageData imgData, List<DisposableNamedOnnxValue> tensorOutput, MatchOptions matchOptions)
+    {
+        // var boxOutput = tensorOutput.First(to => to.ElementType == TensorElementType.Float && to.);
+        // var scoreOutput = tensorOutput.First(to => to.Name == "output2");
+        var labelOutput = tensorOutput.First(to => to.ElementType == TensorElementType.Int32); //output3
+
+        var floatTensors = tensorOutput.Where(to => to.ElementType == TensorElementType.Float).Select(to => to.AsTensor<float>()).ToList();
+        var rawScores = floatTensors.First(ft => ft.Length < 1000);
+        var rawBoxes = floatTensors.First(ft => ft.Length > 1000);
+        var rawLabels = labelOutput.AsTensor<int>();
+
+        var length = rawLabels.Length;
+        if (rawLabels.Last() == -1)
+        {
+            var validLabels = rawLabels.TakeWhile(l => l != -1).ToList();
+            length = validLabels.Count;
+        }
+
+        var results = new List<Classification>();
+        var boxes = rawBoxes.Chunk(4).ToList();
+
+        for (int i = 0; i < length; i++)
+        {
+            var confidence = rawScores.ElementAtOrDefault(i);
+            string? className = null;
+            try
+            {
+                var classNameIndex = rawLabels.ElementAt(i);
+                className = ClassList[classNameIndex];
+            }
+            catch
+            {
+                //ignored since it's clearly fucked
+            }
+            if (confidence > 0 && !string.IsNullOrWhiteSpace(className) && boxes.Count > i)
+            {
+                if (confidence >= matchOptions.GetScoreForClass(className))
+                {
+                    var box = boxes.ElementAt(i).ToBox(imgData.ScaleFactor, imgData.SampleOffset);
+                    results.Add(new Classification(box, confidence, className));
+                    // yield return new Classification(box, confidence, className);
+                }
+            }
+        }
+        return results;
     }
 }

--- a/src/CensorCore/BodyAIService.cs
+++ b/src/CensorCore/BodyAIService.cs
@@ -2,139 +2,155 @@ using Microsoft.ML.OnnxRuntime;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
-namespace CensorCore {
-    public class BodyAIService : IAIService<BoundingBox> {
-        private readonly InferenceSession _session;
-        private readonly IImageHandler _imageHandler;
+namespace CensorCore;
 
-        public bool FilterOutput {get;set;} = false;
+public class BodyAIService : IAIService<BoundingBox>
+{
+    private readonly InferenceSession _session;
+    private readonly IImageHandler _imageHandler;
 
-        public bool Verbose { get ;set; } = false;
+    public bool FilterOutput { get; set; } = false;
 
-        public SessionOptions Options => new SessionOptions() {
-            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+    public bool Verbose { get; set; } = false;
+
+    public SessionOptions Options => new SessionOptions()
+    {
+        GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+    };
+
+    public BodyAIService(InferenceSession session, IImageHandler imageHandler)
+    {
+        this._session = session;
+        this._imageHandler = imageHandler;
+    }
+
+    public async Task<ImageResult<BoundingBox>?> RunModel(byte[] data, MatchOptions? options = null)
+    {
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Start();
+        var imageData = await this._imageHandler.LoadImageData(data);
+        timer.Stop();
+        Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
+        var result = await RunModelForImage(imageData, options);
+        if (result != null && result.Session != null)
+        {
+            result.Session.ImageLoadTime = timer.Elapsed;
+        }
+        return result;
+    }
+
+    public async Task<ImageResult<BoundingBox>?> RunModel(string url, MatchOptions? options = null)
+    {
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Start();
+        var imageData = await this._imageHandler.LoadImage(url);
+        timer.Stop();
+        Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
+        var result = await RunModelForImage(imageData, options);
+        if (result != null && result.Session != null)
+        {
+            result.Session.ImageLoadTime = timer.Elapsed;
+        }
+        return result;
+    }
+
+    private void Log(string message)
+    {
+        if (Verbose)
+        {
+            Console.WriteLine(message);
+        }
+    }
+
+    internal async Task<ImageResult<BoundingBox>?> RunModelForImage(ImageData imageData, MatchOptions? options)
+    {
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Restart();
+        var tensorOpts = new RobustVideoOptions();
+        var modelInput = await this._imageHandler.LoadToTensor<float>(imageData, tensorOpts);
+        timer.Stop();
+        var tensorLoadTime = timer.Elapsed;
+        Log($"Loaded tensor data in {timer.Elapsed.TotalSeconds}s");
+        timer.Restart();
+        var feeds = tensorOpts.GetFeeds(_session, modelInput).ToList();
+        var output = this._session.Run(feeds);
+        var runTime = timer.Elapsed;
+        Log($"Finished model in {timer.Elapsed.TotalSeconds}s");
+        timer.Restart();
+        var classifications = this.GetResults(imageData, output.ToList(), MatchOptions.GetDefault()).ToList();
+        var modelName = string.IsNullOrWhiteSpace(this._session.ModelMetadata.Description)
+            ? this._session.ModelMetadata.GraphName
+            : this._session.ModelMetadata.Description;
+        var sessionMeta = new SessionMetadata(modelName, runTime)
+        {
+            TensorLoadTime = tensorLoadTime
+        };
+        var result = new ImageResult<BoundingBox>(imageData, classifications)
+        {
+            Session = sessionMeta
         };
 
-        public BodyAIService(InferenceSession session, IImageHandler imageHandler) {
-            this._session = session;
-            this._imageHandler = imageHandler;
-        }
+        Log($"Built results in {timer.Elapsed.TotalSeconds}s");
+        timer.Reset();
+        return result;
+    }
 
-        public async Task<ImageResult<BoundingBox>?> RunModel(byte[] data, MatchOptions? options = null) {
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Start();
-            var imageData = await this._imageHandler.LoadImageData(data);
-            timer.Stop();
-            Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
-            var result = await RunModelForImage(imageData, options);
-            if (result != null && result.Session != null) {
-                result.Session.ImageLoadTime = timer.Elapsed;
-            }
-            return result;
-        }
+    private IEnumerable<BoundingBox> GetResults(ImageData imgData, List<DisposableNamedOnnxValue> tensorOutput, MatchOptions matchOptions)
+    {
+        var results = tensorOutput.ToArray();
+        var length = results.Length;
+        var img = imgData.SampledImage ?? imgData.SourceImage;
+        var foreground = results[0].AsTensor<float>().ToList();
+        var alphaPred = results[1].AsTensor<float>().ToList();
+        int newMinX = img.Width;
+        int newMinY = img.Height;
+        int newMaxX = 0;
+        int newMaxY = 0;
 
-        public async Task<ImageResult<BoundingBox>?> RunModel(string url, MatchOptions? options = null) {
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Start();
-            var imageData = await this._imageHandler.LoadImage(url);
-            timer.Stop();
-            Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
-            var result = await RunModelForImage(imageData, options);
-            if (result != null && result.Session != null) {
-                result.Session.ImageLoadTime = timer.Elapsed;
-            }
-            return result;
-        }
-
-        private void Log(string message) {
-            if (Verbose) {
-                Console.WriteLine(message);
-            }
-        }
-
-        internal async Task<ImageResult<BoundingBox>?> RunModelForImage(ImageData imageData, MatchOptions? options) {
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Restart();
-            var tensorOpts = new RobustVideoOptions();
-            var modelInput = await this._imageHandler.LoadToTensor<float>(imageData, tensorOpts);
-            timer.Stop();
-            var tensorLoadTime = timer.Elapsed;
-            Log($"Loaded tensor data in {timer.Elapsed.TotalSeconds}s");
-            timer.Restart();
-            var feeds = tensorOpts.GetFeeds(_session, modelInput).ToList();
-            var output = this._session.Run(feeds);
-            var runTime = timer.Elapsed;
-            Log($"Finished model in {timer.Elapsed.TotalSeconds}s");
-            timer.Restart();
-            var classifications = this.GetResults(imageData, output.ToList(), MatchOptions.GetDefault()).ToList();
-            var modelName = string.IsNullOrWhiteSpace(this._session.ModelMetadata.Description)
-                ? this._session.ModelMetadata.GraphName
-                : this._session.ModelMetadata.Description;
-            var sessionMeta = new SessionMetadata(modelName, runTime) {
-                TensorLoadTime = tensorLoadTime
-            };
-            var result = new ImageResult<BoundingBox>(imageData, classifications) {
-                Session = sessionMeta
-            };
-            
-            Log($"Built results in {timer.Elapsed.TotalSeconds}s");
-            timer.Reset();
-            return result;
-        }
-
-        private IEnumerable<BoundingBox> GetResults(ImageData imgData, List<DisposableNamedOnnxValue> tensorOutput, MatchOptions matchOptions) {
-            var results = tensorOutput.ToArray();
-            var length = results.Length;
-            var img = imgData.SampledImage ?? imgData.SourceImage;
-            var foreground = results[0].AsTensor<float>().ToList();
-            var alphaPred = results[1].AsTensor<float>().ToList();
-            int newMinX = img.Width;
-            int newMinY = img.Height;
-            int newMaxX = 0;
-            int newMaxY = 0;
-            
-            img.ProcessPixelRows(accessor =>
+        img.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0, k = 0; y < accessor.Height; y++)
             {
-                for (int y = 0, k = 0; y < accessor.Height; y++)
-                {
-                    var pixelRow = accessor.GetRowSpan(y);
+                var pixelRow = accessor.GetRowSpan(y);
 
-                    for (int x = 0; x < pixelRow.Length; x++)
+                for (int x = 0; x < pixelRow.Length; x++)
+                {
+                    // Get a reference to the pixel at position x
+                    ref Rgba32 pixel = ref pixelRow[x];
+                    var a = alphaPred[k++];
+                    if (a > 0.5F)
                     {
-                        // Get a reference to the pixel at position x
-                        ref Rgba32 pixel = ref pixelRow[x];
-                        var a = alphaPred[k++];
-                        if (a > 0.5F) {
-                            newMinX = Math.Min(newMinX, x);
-                            newMinY = Math.Min(newMinY, y);
-                            newMaxX = Math.Max(newMaxX, x);
-                            newMaxY = Math.Max(newMaxY, y);
-                        }
-                        if (FilterOutput) {
-                            pixel.R = (byte)(pixel.R*a);
-                            pixel.G = (byte)(pixel.G*a);
-                            pixel.B = (byte)(pixel.B*a);
-                            pixel.A = (byte)(pixel.A*a);
-                        }
+                        newMinX = Math.Min(newMinX, x);
+                        newMinY = Math.Min(newMinY, y);
+                        newMaxX = Math.Max(newMaxX, x);
+                        newMaxY = Math.Max(newMaxY, y);
+                    }
+                    if (FilterOutput)
+                    {
+                        pixel.R = (byte)(pixel.R * a);
+                        pixel.G = (byte)(pixel.G * a);
+                        pixel.B = (byte)(pixel.B * a);
+                        pixel.A = (byte)(pixel.A * a);
                     }
                 }
-            });
-            var rect = Rectangle.FromLTRB(newMinX, newMinY, newMaxX, newMaxY);
-            return new[] {new BoundingBox(rect.X, rect.Y, rect.X+rect.Width, rect.Y+rect.Height)};
-        }
+            }
+        });
+        var rect = Rectangle.FromLTRB(newMinX, newMinY, newMaxX, newMaxY);
+        return new[] { new BoundingBox(rect.X, rect.Y, rect.X + rect.Width, rect.Y + rect.Height) };
+    }
 
-        private RectangleF GetFromAlphaPixels(List<float> alphaPred, int imageWidth, float threshold = 0.5F) {
-            // var timer = new System.Diagnostics.Stopwatch();
-            // timer.Start();
-            var rows = alphaPred.Chunk(imageWidth).Select(ch => ch.ToList()).ToList();
-            var minX = rows.Select(ch => ch.IndexOf(ch.FirstOrDefault(ap => ap > 0.5F))).Where(api => api != default(float)).Min();
-            var minY = rows.IndexOf(rows.FirstOrDefault(ro => ro.Any(p => p > 0.5F)) ?? rows.First());
-            var maxX = rows.Select(ch => ch.IndexOf(ch.LastOrDefault(ap => ap > 0.5F))).Where(api => api != default(float)).Max();
-            var maxY = rows.IndexOf(rows.LastOrDefault(ro => ro.Any(ap => ap > 0.5F)) ?? rows.Last());
-            // var listMethod = timer.Elapsed.TotalSeconds;
-            // timer.Restart();
-            var rect = Rectangle.FromLTRB(minX, minY, maxX, maxY);
-            return rect;
-        }
+    private RectangleF GetFromAlphaPixels(List<float> alphaPred, int imageWidth, float threshold = 0.5F)
+    {
+        // var timer = new System.Diagnostics.Stopwatch();
+        // timer.Start();
+        var rows = alphaPred.Chunk(imageWidth).Select(ch => ch.ToList()).ToList();
+        var minX = rows.Select(ch => ch.IndexOf(ch.FirstOrDefault(ap => ap > 0.5F))).Where(api => api != default(float)).Min();
+        var minY = rows.IndexOf(rows.FirstOrDefault(ro => ro.Any(p => p > 0.5F)) ?? rows.First());
+        var maxX = rows.Select(ch => ch.IndexOf(ch.LastOrDefault(ap => ap > 0.5F))).Where(api => api != default(float)).Max();
+        var maxY = rows.IndexOf(rows.LastOrDefault(ro => ro.Any(ap => ap > 0.5F)) ?? rows.Last());
+        // var listMethod = timer.Elapsed.TotalSeconds;
+        // timer.Restart();
+        var rect = Rectangle.FromLTRB(minX, minY, maxX, maxY);
+        return rect;
     }
 }

--- a/src/CensorCore/BodyAreaImageHandler.cs
+++ b/src/CensorCore/BodyAreaImageHandler.cs
@@ -5,14 +5,16 @@ using CensorCore.Censoring;
 
 namespace CensorCore;
 
-public enum OptimizationMode {
+public enum OptimizationMode
+{
     None,
     Normal,
     Aggressive
 
 }
 
-public class BodyAreaImageHandler : IImageHandler {
+public class BodyAreaImageHandler : IImageHandler
+{
     private readonly IImageHandler _imageHandler;
     private readonly OptimizationMode _mode;
     private readonly BodyAIService _bodyAi;
@@ -21,7 +23,8 @@ public class BodyAreaImageHandler : IImageHandler {
     {
         var model = GetModelResource();
         _imageHandler = implHandler;
-        var opts = new SessionOptions() {
+        var opts = new SessionOptions()
+        {
             GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
         };
         var fSession = new InferenceSession(model, opts);
@@ -30,15 +33,18 @@ public class BodyAreaImageHandler : IImageHandler {
         _bodyAi = fService;
         _bodyAi.FilterOutput = _mode == OptimizationMode.Aggressive;
     }
-    public Task<ImageData> LoadImage(string path) {
+    public Task<ImageData> LoadImage(string path)
+    {
         return _imageHandler.LoadImage(path);
     }
 
-    public Task<ImageData> LoadImageData(byte[] data) {
+    public Task<ImageData> LoadImageData(byte[] data)
+    {
         return _imageHandler.LoadImageData(data);
     }
 
-    public async Task<InputImage<T>> LoadToTensor<T>(ImageData imageData, TensorLoadOptions<T> options) {
+    public async Task<InputImage<T>> LoadToTensor<T>(ImageData imageData, TensorLoadOptions<T> options)
+    {
         switch (_mode)
         {
             case OptimizationMode.None:
@@ -51,44 +57,53 @@ public class BodyAreaImageHandler : IImageHandler {
         }
     }
 
-    private async Task<InputImage<T>?> LoadCropped<T>(ImageData imageData, TensorLoadOptions<T> options) {
-        try {
-        var timer = new System.Diagnostics.Stopwatch();
-        var result = await _bodyAi.RunModelForImage(imageData, null);
-        if (result != null && result.Session != null) {
-            result.Session.ImageLoadTime = timer.Elapsed;
+    private async Task<InputImage<T>?> LoadCropped<T>(ImageData imageData, TensorLoadOptions<T> options)
+    {
+        try
+        {
+            var timer = new System.Diagnostics.Stopwatch();
+            var result = await _bodyAi.RunModelForImage(imageData, null);
+            if (result != null && result.Session != null)
+            {
+                result.Session.ImageLoadTime = timer.Elapsed;
+            }
+            if (result == null || !result.Results.Any())
+            {
+                return null;
+            }
+            var box = result.Results.First();
+            var cropped = result.ImageData.SampledImage.Clone(x => x.Crop(box.ToRectangle()));
+            imageData.SampledImage = cropped;
+            imageData.SampleOffset = (Point)new PointF(box.X, box.Y);
+            var origHeight = result.ImageData.SourceImage.Height;
+            var scaleSize = new SizeF((float)result.ImageData.SourceImage.Width / cropped.Width, (float)result.ImageData.SourceImage.Height / cropped.Height);
+            // imageData.ScaleFactor = scaleSize;
+            var baseResult = await _imageHandler.LoadToTensor<T>(imageData, options);
+            return baseResult;
         }
-        if (result == null || !result.Results.Any()) {
-            return null;
-        }
-        var box = result.Results.First();
-        var cropped = result.ImageData.SampledImage.Clone(x => x.Crop(box.ToRectangle()));
-        imageData.SampledImage = cropped;
-        imageData.SampleOffset = (Point)new PointF(box.X, box.Y);
-        var origHeight = result.ImageData.SourceImage.Height;
-        var scaleSize = new SizeF((float)result.ImageData.SourceImage.Width / cropped.Width, (float)result.ImageData.SourceImage.Height / cropped.Height);
-        // imageData.ScaleFactor = scaleSize;
-        var baseResult = await _imageHandler.LoadToTensor<T>(imageData, options);
-        return baseResult;
-        } catch {
+        catch
+        {
             return null;
         }
     }
 
-    private static byte[]? GetModelResource(System.Reflection.Assembly? assembly = null) {
+    private static byte[]? GetModelResource(System.Reflection.Assembly? assembly = null)
+    {
 
-            var entryAssembly = assembly ?? typeof(FacialFeaturesMiddleware).Assembly;
-            var model = entryAssembly.GetManifestResourceNames();
-            //TODO: this doesn't match right
-            if (model != null && model.Any() && model.FirstOrDefault(r => r.Contains("rvm") && r.EndsWith(".onnx")) is var modelResource && modelResource != null) {
-                // Console.WriteLine($"reading stream from {modelResource}");
-                using var resourceStream = entryAssembly.GetManifestResourceStream(modelResource);
-                if (resourceStream != null && resourceStream.CanRead) {
-                    using var ms = new MemoryStream();
-                    resourceStream.CopyTo(ms);
-                    return ms.ToArray();
-                }
+        var entryAssembly = assembly ?? typeof(FacialFeaturesMiddleware).Assembly;
+        var model = entryAssembly.GetManifestResourceNames();
+        //TODO: this doesn't match right
+        if (model != null && model.Any() && model.FirstOrDefault(r => r.Contains("rvm") && r.EndsWith(".onnx")) is var modelResource && modelResource != null)
+        {
+            // Console.WriteLine($"reading stream from {modelResource}");
+            using var resourceStream = entryAssembly.GetManifestResourceStream(modelResource);
+            if (resourceStream != null && resourceStream.CanRead)
+            {
+                using var ms = new MemoryStream();
+                resourceStream.CopyTo(ms);
+                return ms.ToArray();
             }
-            return null;
         }
+        return null;
+    }
 }

--- a/src/CensorCore/CensorCore.csproj
+++ b/src/CensorCore/CensorCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flurl" Version="3.0.6" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.12.1" />
+    <PackageReference Include="Flurl" Version="4.0.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.18.0" />
     <!-- <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.10.0" /> -->
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
-    <PackageReference Include="System.Numerics.Tensors" Version="0.1.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.3" />
+    <PackageReference Include="System.Numerics.Tensors" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CensorCore/CensorCore.csproj
+++ b/src/CensorCore/CensorCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CensorCore.props" />
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl" Version="4.0.0" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.18.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.21.0" />
     <!-- <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.10.0" /> -->
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.3" />
-    <PackageReference Include="System.Numerics.Tensors" Version="8.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.5" />
+    <PackageReference Include="System.Numerics.Tensors" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CensorCore/Censoring/BlackBarProvider.cs
+++ b/src/CensorCore/Censoring/BlackBarProvider.cs
@@ -1,19 +1,19 @@
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 
 
-namespace CensorCore.Censoring {
+namespace CensorCore.Censoring;
 
-    public class BlackBarProvider : ICensorTypeProvider {
-        public Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level) {
-            return Task.FromResult<Action<IImageProcessingContext>?>(CensorEffects.GetBlackBarEffect(inputImage, result, level));
-        }
-
-        public int Layer => 10;
-
-        public bool Supports(string censorType) => censorType.Contains("bars") || censorType == "bb" || censorType.Contains("blackb");
+public class BlackBarProvider : ICensorTypeProvider
+{
+    public Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level)
+    {
+        return Task.FromResult<Action<IImageProcessingContext>?>(CensorEffects.GetBlackBarEffect(inputImage, result, level));
     }
+
+    public int Layer => 10;
+
+    public bool Supports(string censorType) => censorType.Contains("bars") || censorType == "bb" || censorType.Contains("blackb");
 }

--- a/src/CensorCore/Censoring/BlurProvider.cs
+++ b/src/CensorCore/Censoring/BlurProvider.cs
@@ -2,21 +2,25 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
-namespace CensorCore.Censoring {
-    public class BlurProvider : ICensorTypeProvider {
-        private readonly GlobalCensorOptions _globalOpts;
+namespace CensorCore.Censoring;
 
-        public BlurProvider(GlobalCensorOptions globalOpts) {
-            this._globalOpts = globalOpts;
-        }
-        public BlurProvider() {
-            _globalOpts = new GlobalCensorOptions();
-        }
-        public Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level) {
-            var padding = inputImage.GetPadding(_globalOpts);
-            var overrideScale = _globalOpts.ClassStrength.GetValueOrDefault(result.Label, 1F);
-            var mutation = CensorEffects.GetMaskedBlurEffect(inputImage, result, padding, level, overrideScale);
-            return Task.FromResult<Action<IImageProcessingContext>?>(mutation);
-        }
+public class BlurProvider : ICensorTypeProvider
+{
+    private readonly GlobalCensorOptions _globalOpts;
+
+    public BlurProvider(GlobalCensorOptions globalOpts)
+    {
+        this._globalOpts = globalOpts;
+    }
+    public BlurProvider()
+    {
+        _globalOpts = new GlobalCensorOptions();
+    }
+    public Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level)
+    {
+        var padding = inputImage.GetPadding(_globalOpts);
+        var overrideScale = _globalOpts.ClassStrength.GetValueOrDefault(result.Label, 1F);
+        var mutation = CensorEffects.GetMaskedBlurEffect(inputImage, result, padding, level, overrideScale);
+        return Task.FromResult<Action<IImageProcessingContext>?>(mutation);
     }
 }

--- a/src/CensorCore/Censoring/CaptionProvider.cs
+++ b/src/CensorCore/Censoring/CaptionProvider.cs
@@ -1,74 +1,85 @@
 using SixLabors.Fonts;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 
 
-namespace CensorCore.Censoring {
-    public class CaptionProvider : ICensorTypeProvider {
-        private readonly FontCollection _fonts;
-        private readonly GlobalCensorOptions _globalOpts;
-        private readonly IAssetStore _assetStore;
+namespace CensorCore.Censoring;
 
-        public CaptionProvider(IAssetStore assetStore, FontCollection? fonts = null, GlobalCensorOptions? opts = null) =>
-            (_assetStore, _fonts, _globalOpts) = (assetStore, fonts ?? GetDefaultFontCollection(), opts ?? new GlobalCensorOptions());
+public class CaptionProvider : ICensorTypeProvider
+{
+    private readonly FontCollection _fonts;
+    private readonly GlobalCensorOptions _globalOpts;
+    private readonly IAssetStore _assetStore;
 
-        // public bool Supports(string censorType) => censorType.StartsWith("caption");
-        public int Layer => 6;
+    public CaptionProvider(IAssetStore assetStore, FontCollection? fonts = null, GlobalCensorOptions? opts = null) =>
+        (_assetStore, _fonts, _globalOpts) = (assetStore, fonts ?? GetDefaultFontCollection(), opts ?? new GlobalCensorOptions());
 
-        public async Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level) {
-            var mutations = new List<Action<IImageProcessingContext>>();
-            var padding = inputImage.GetPadding(_globalOpts);
-            float boxRatio = (float)result.Box.Width / result.Box.Height;
-            var opts = method.GetCaptionOptions("caption");
-            var categories = opts.Categories;
-            var caption = await _assetStore.GetRandomCaption(categories?.Random());
-            var cropRect = result.Box.ToRectangle();
+    // public bool Supports(string censorType) => censorType.StartsWith("caption");
+    public int Layer => 6;
 
-            if (opts.PreferBox) {
-                var bar = CensorEffects.GetBlackBarEffect(inputImage, result, level);
-                mutations.Add(bar);
-            } else {
-                var blur = CensorEffects.GetMaskedBlurEffect(inputImage, result, padding, level, minimumLevel: 10);
-                mutations.Add(blur);
-            }
-            
-            if (caption != null) {
-                var levelDiff = ((level-10F)*0.75F)+10F;
-                var fontSize = (result.Box.Width/4F)*(levelDiff.GetScaleFactor(10F));
-                var font = _fonts.Families.First().CreateFont(fontSize, FontStyle.Bold);
-                // The options are optional
-                RichTextOptions options = new(font) {
-                    Origin = cropRect.GetCenter(), // Set the rendering origin.
-                    TabWidth = 4, // A tab renders as 8 spaces wide
-                    WrappingLength = opts.WrapText ? result.Box.Width : 0, // Greater than zero so we will word wrap at 100 pixels wide
-                    HorizontalAlignment = HorizontalAlignment.Center,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    TextAlignment = TextAlignment.Center
-                };
-                
-                Brush brush = Brushes.Solid(Color.White);
-                Pen pen = Pens.Solid(Color.Black, (result.Box.Width/80F)*(level.GetScaleFactor(10F)));
-                if (result.SourceAngle.HasValue) {
-                    var drawOpts = new DrawingOptions() { Transform = Matrix3x2Extensions.CreateRotationDegrees(result.SourceAngle.Value, result.Box.GetCenter())};
-                    mutations.Add(x => x.DrawText(drawOpts, options, caption.ToUpper(), brush, pen));
-                } else {
-                    mutations.Add(x => x.DrawText(options, caption.ToUpper(), brush, pen));
-                }
-            }
-            return x =>
+    public async Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level)
+    {
+        var mutations = new List<Action<IImageProcessingContext>>();
+        var padding = inputImage.GetPadding(_globalOpts);
+        float boxRatio = (float)result.Box.Width / result.Box.Height;
+        var opts = method.GetCaptionOptions("caption");
+        var categories = opts.Categories;
+        var caption = await _assetStore.GetRandomCaption(categories?.Random());
+        var cropRect = result.Box.ToRectangle();
+
+        if (opts.PreferBox)
+        {
+            var bar = CensorEffects.GetBlackBarEffect(inputImage, result, level);
+            mutations.Add(bar);
+        }
+        else
+        {
+            var blur = CensorEffects.GetMaskedBlurEffect(inputImage, result, padding, level, minimumLevel: 10);
+            mutations.Add(blur);
+        }
+
+        if (caption != null)
+        {
+            var levelDiff = ((level - 10F) * 0.75F) + 10F;
+            var fontSize = (result.Box.Width / 4F) * (levelDiff.GetScaleFactor(10F));
+            var font = _fonts.Families.First().CreateFont(fontSize, FontStyle.Bold);
+            // The options are optional
+            RichTextOptions options = new(font)
             {
-                foreach (var mutation in mutations) {
-                    mutation(x);
-                }
+                Origin = cropRect.GetCenter(), // Set the rendering origin.
+                TabWidth = 4, // A tab renders as 8 spaces wide
+                WrappingLength = opts.WrapText ? result.Box.Width : 0, // Greater than zero so we will word wrap at 100 pixels wide
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                TextAlignment = TextAlignment.Center
             };
-        }
 
-        internal static FontCollection GetDefaultFontCollection() {
-            return new EmbeddedFontProvider().LoadEmbeddedFonts().GetCollection();
+            Brush brush = Brushes.Solid(Color.White);
+            Pen pen = Pens.Solid(Color.Black, (result.Box.Width / 80F) * (level.GetScaleFactor(10F)));
+            if (result.SourceAngle.HasValue)
+            {
+                var drawOpts = new DrawingOptions() { Transform = Matrix3x2Extensions.CreateRotationDegrees(result.SourceAngle.Value, result.Box.GetCenter()) };
+                mutations.Add(x => x.DrawText(drawOpts, options, caption.ToUpper(), brush, pen));
+            }
+            else
+            {
+                mutations.Add(x => x.DrawText(options, caption.ToUpper(), brush, pen));
+            }
         }
+        return x =>
+        {
+            foreach (var mutation in mutations)
+            {
+                mutation(x);
+            }
+        };
+    }
+
+    internal static FontCollection GetDefaultFontCollection()
+    {
+        return new EmbeddedFontProvider().LoadEmbeddedFonts().GetCollection();
     }
 }

--- a/src/CensorCore/Censoring/CaptionProvider.cs
+++ b/src/CensorCore/Censoring/CaptionProvider.cs
@@ -41,7 +41,7 @@ namespace CensorCore.Censoring {
                 var fontSize = (result.Box.Width/4F)*(levelDiff.GetScaleFactor(10F));
                 var font = _fonts.Families.First().CreateFont(fontSize, FontStyle.Bold);
                 // The options are optional
-                TextOptions options = new(font) {
+                RichTextOptions options = new(font) {
                     Origin = cropRect.GetCenter(), // Set the rendering origin.
                     TabWidth = 4, // A tab renders as 8 spaces wide
                     WrappingLength = opts.WrapText ? result.Box.Width : 0, // Greater than zero so we will word wrap at 100 pixels wide
@@ -49,8 +49,9 @@ namespace CensorCore.Censoring {
                     VerticalAlignment = VerticalAlignment.Center,
                     TextAlignment = TextAlignment.Center
                 };
-                IBrush brush = Brushes.Solid(Color.White);
-                IPen pen = Pens.Solid(Color.Black, (result.Box.Width/80F)*(level.GetScaleFactor(10F)));
+                
+                Brush brush = Brushes.Solid(Color.White);
+                Pen pen = Pens.Solid(Color.Black, (result.Box.Width/80F)*(level.GetScaleFactor(10F)));
                 if (result.SourceAngle.HasValue) {
                     var drawOpts = new DrawingOptions() { Transform = Matrix3x2Extensions.CreateRotationDegrees(result.SourceAngle.Value, result.Box.GetCenter())};
                     mutations.Add(x => x.DrawText(drawOpts, options, caption.ToUpper(), brush, pen));

--- a/src/CensorCore/Censoring/CensorEffects.cs
+++ b/src/CensorCore/Censoring/CensorEffects.cs
@@ -3,60 +3,67 @@ using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Processing;
 
-namespace CensorCore.Censoring {
-    public static class CensorEffects {
-        public static Action<IImageProcessingContext> GetMaskedBlurEffect(Image inputImage, Classification result, int padding, int level, float sizeFactor = 1F, float minimumLevel = 1F) {
-            var cropRect = result.Box.ToRectangle();
-            var mask = new PathEffectMask(cropRect, result.SourceAngle.GetValueOrDefault(), padding);
-            var extract = inputImage.Clone(x =>
-            {
-                x.Crop((Rectangle)mask.GetBounds(inputImage));
-                x.GaussianBlur((Math.Max(minimumLevel, level) * Math.Max(2.5F, (Math.Min(cropRect.Width, cropRect.Height) / 100)))*sizeFactor);
-            });
-            return mask.GetMutation(extract);
-        }
+namespace CensorCore.Censoring;
 
-        public static Action<IImageProcessingContext> GetMaskedPixelEffect(Image inputImage, Classification result, int padding, int level, float sizeFactor = 1F) {
-            var cropRect = result.Box.ToRectangle();
-            var mask = new PathEffectMask(cropRect, result.SourceAngle.GetValueOrDefault(), padding);
-            var extract = inputImage.Clone(x => {
-                x.Crop((Rectangle)mask.GetBounds(inputImage));
-                x.Pixelate(GetPixelSize(Math.Max(inputImage.Height, inputImage.Width), level, sizeFactor));
-            });
-            return mask.GetMutation(extract);
-        }
+public static class CensorEffects
+{
+    public static Action<IImageProcessingContext> GetMaskedBlurEffect(Image inputImage, Classification result, int padding, int level, float sizeFactor = 1F, float minimumLevel = 1F)
+    {
+        var cropRect = result.Box.ToRectangle();
+        var mask = new PathEffectMask(cropRect, result.SourceAngle.GetValueOrDefault(), padding);
+        var extract = inputImage.Clone(x =>
+        {
+            x.Crop((Rectangle)mask.GetBounds(inputImage));
+            x.GaussianBlur((Math.Max(minimumLevel, level) * Math.Max(2.5F, (Math.Min(cropRect.Width, cropRect.Height) / 100))) * sizeFactor);
+        });
+        return mask.GetMutation(extract);
+    }
 
-        private static int GetPixelSize(int dimension, int level, float scale, int minimumSize = 5) {
-            var inverted = 21-level;
-            return Math.Max(minimumSize, Convert.ToInt32(Math.Round((dimension/3F)/(Math.Max(inverted, 5))*0.75)*scale));
-        }
+    public static Action<IImageProcessingContext> GetMaskedPixelEffect(Image inputImage, Classification result, int padding, int level, float sizeFactor = 1F)
+    {
+        var cropRect = result.Box.ToRectangle();
+        var mask = new PathEffectMask(cropRect, result.SourceAngle.GetValueOrDefault(), padding);
+        var extract = inputImage.Clone(x =>
+        {
+            x.Crop((Rectangle)mask.GetBounds(inputImage));
+            x.Pixelate(GetPixelSize(Math.Max(inputImage.Height, inputImage.Width), level, sizeFactor));
+        });
+        return mask.GetMutation(extract);
+    }
 
-        private static int GetPixelSize(int dimension, BoundingBox box, int level, int minimumSize = 5) {
-            var inverted = 21-level;
-            var scaledSize = Convert.ToInt32(Math.Round((Math.Min(box.Height, box.Width))/1F)/(Math.Max(inverted, 5))/2F);
-            var imageSize = Math.Max(minimumSize, Convert.ToInt32(Math.Round(((dimension/3F)/(Math.Max(inverted, 5))*0.75)*1)));
-            var ratioDiff = 1F-((float)Math.Min(box.Height, box.Width)/(float)Math.Max(box.Height, box.Width));
-            var factor = 1/(1+(ratioDiff*(float)minimumSize));
-            var final = Convert.ToInt32(Math.Round(imageSize * factor));
-            // Console.WriteLine($"Normalizing size of {imageSize} using {factor}/{ratioDiff} to {final}");
-            return final;
-        }
+    private static int GetPixelSize(int dimension, int level, float scale, int minimumSize = 5)
+    {
+        var inverted = 21 - level;
+        return Math.Max(minimumSize, Convert.ToInt32(Math.Round((dimension / 3F) / (Math.Max(inverted, 5)) * 0.75) * scale));
+    }
 
-        public static Action<IImageProcessingContext> GetBlackBarEffect(Image inputImage, Classification result, int level) {
-            var rect = new RectangularPolygon(result.Box.X, result.Box.Y, result.Box.Width, result.Box.Height);
-            var blackBrush = Brushes.Solid(Color.Black);
-            var adjustFactor = (-(10 - (float)level) * 2) / 100;
-            var adjBox = result.Box.ScaleBy(result.Box.Width * adjustFactor, result.Box.Height * adjustFactor);
-            var drawOpts = result.SourceAngle != null
-                ? new DrawingOptions() { Transform = Matrix3x2Extensions.CreateRotationDegrees(result.SourceAngle.Value, result.Box.GetCenter()) }
-                : new DrawingOptions();
-            return (x =>
+    private static int GetPixelSize(int dimension, BoundingBox box, int level, int minimumSize = 5)
+    {
+        var inverted = 21 - level;
+        var scaledSize = Convert.ToInt32(Math.Round((Math.Min(box.Height, box.Width)) / 1F) / (Math.Max(inverted, 5)) / 2F);
+        var imageSize = Math.Max(minimumSize, Convert.ToInt32(Math.Round(((dimension / 3F) / (Math.Max(inverted, 5)) * 0.75) * 1)));
+        var ratioDiff = 1F - ((float)Math.Min(box.Height, box.Width) / (float)Math.Max(box.Height, box.Width));
+        var factor = 1 / (1 + (ratioDiff * (float)minimumSize));
+        var final = Convert.ToInt32(Math.Round(imageSize * factor));
+        // Console.WriteLine($"Normalizing size of {imageSize} using {factor}/{ratioDiff} to {final}");
+        return final;
+    }
+
+    public static Action<IImageProcessingContext> GetBlackBarEffect(Image inputImage, Classification result, int level)
+    {
+        var rect = new RectangularPolygon(result.Box.X, result.Box.Y, result.Box.Width, result.Box.Height);
+        var blackBrush = Brushes.Solid(Color.Black);
+        var adjustFactor = (-(10 - (float)level) * 2) / 100;
+        var adjBox = result.Box.ScaleBy(result.Box.Width * adjustFactor, result.Box.Height * adjustFactor);
+        var drawOpts = result.SourceAngle != null
+            ? new DrawingOptions() { Transform = Matrix3x2Extensions.CreateRotationDegrees(result.SourceAngle.Value, result.Box.GetCenter()) }
+            : new DrawingOptions();
+        return (x =>
                 x.FillPolygon(drawOpts, blackBrush,
                     new PointF(result.Box.X, result.Box.Y),
                     new PointF(result.Box.X + result.Box.Width, result.Box.Y),
                     new PointF(result.Box.X + result.Box.Width, result.Box.Y + result.Box.Height),
                     new PointF(result.Box.X, result.Box.Y + result.Box.Height))
-                );
-        }
+            );
     }
 }

--- a/src/CensorCore/Censoring/EffectMask.cs
+++ b/src/CensorCore/Censoring/EffectMask.cs
@@ -5,155 +5,169 @@ using SixLabors.ImageSharp.Processing;
 
 
 
-namespace CensorCore.Censoring
+namespace CensorCore.Censoring;
+
+/// <summary>
+/// A helper class for blending censor methods with the surrounding image. 
+/// </summary>
+public class EffectMask
 {
+    private Rectangle _box;
+    private readonly int _padding;
+    private readonly GraphicsOptions _options;
+
     /// <summary>
-    /// A helper class for blending censor methods with the surrounding image. 
+    /// Create an instance of the Mask helper for the given bounding box, optionally with padding.
     /// </summary>
-    public class EffectMask {
-        private Rectangle _box;
-        private readonly int _padding;
-        private readonly GraphicsOptions _options;
+    /// <param name="box">The bounding box used to create the mask.</param>
+    /// <param name="padding">An optional padding to increase the size of the mask.</param>
+    public EffectMask(BoundingBox box, int padding = 0)
+    {
+        this._box = box.ToRectangle();
+        this._padding = padding;
+        this._options = new GraphicsOptions { AlphaCompositionMode = PixelAlphaCompositionMode.SrcIn };
+    }
 
-        /// <summary>
-        /// Create an instance of the Mask helper for the given bounding box, optionally with padding.
-        /// </summary>
-        /// <param name="box">The bounding box used to create the mask.</param>
-        /// <param name="padding">An optional padding to increase the size of the mask.</param>
-        public EffectMask(BoundingBox box, int padding = 0)
+    public EffectMask(Rectangle rect, int padding = 0)
+    {
+        this._box = rect;
+        this._padding = padding;
+        this._options = new GraphicsOptions { AlphaCompositionMode = PixelAlphaCompositionMode.SrcIn };
+    }
+
+    private Image<Rgba32> GetMaskBase()
+    {
+        return new Image<Rgba32>(this._box.Width + (this._padding * 2), this._box.Height + (this._padding * 2), Rgba32.ParseHex("#00000000"));
+    }
+
+    /// <summary>
+    /// Gets the mask image to apply to an image.
+    /// </summary>
+    /// <returns>An image of the mask. Contains *only* the mask, not the "real" image.</returns>
+    public Image<Rgba32> GetMask()
+    {
+        var mask = GetMaskBase();
+        float threshold = 0.2F;
+        Color sourceColor = Color.White;
+        Color targetColor = Color.Transparent;
+        RecolorBrush brush2 = new RecolorBrush(sourceColor, targetColor, threshold);
+        // var topGrad = new RadialGradientBrush(new PointF(mask.Width/2, mask.Height/2), mask.Height/2, GradientRepetitionMode.None, new ColorStop(0.25F, Color.Transparent), new ColorStop(1, Color.White));
+        // var maskGrad = new RadialGradientBrush(new PointF(mask.Width/2, mask.Height/2), mask.Height/2, GradientRepetitionMode.None, new ColorStop(0F, Color.Black), new ColorStop(0.8F, Color.Black), new ColorStop(0.9F, Color.ParseHex("#00000080")), new ColorStop(1F, Color.Transparent));
+        var landscape = mask.Width > mask.Height;
+        var axisEnd = landscape
+            ? new PointF(mask.Width, mask.Height / 2)
+            : new PointF(mask.Width / 2, mask.Height);
+        var ratio = landscape
+            ? (float)mask.Width / mask.Height
+            : (float)mask.Height / mask.Width;
+        var stops = new ColorStop[] {
+            new ColorStop(0F, Color.Black), new ColorStop(0.66F, Color.Black), new ColorStop(1F, Color.Transparent)
+        };
+        if (ratio < 0.8 || ratio > 1.2)
         {
-            this._box = box.ToRectangle();
-            this._padding = padding;
-            this._options = new GraphicsOptions { AlphaCompositionMode = PixelAlphaCompositionMode.SrcIn };
-        }
-
-        public EffectMask(Rectangle rect, int padding = 0)
-        {
-            this._box = rect;
-            this._padding = padding;
-            this._options = new GraphicsOptions { AlphaCompositionMode = PixelAlphaCompositionMode.SrcIn };
-        }
-
-        private Image<Rgba32> GetMaskBase() {
-            return new Image<Rgba32>(this._box.Width + (this._padding*2), this._box.Height + (this._padding*2), Rgba32.ParseHex("#00000000"));
-        }
-
-        /// <summary>
-        /// Gets the mask image to apply to an image.
-        /// </summary>
-        /// <returns>An image of the mask. Contains *only* the mask, not the "real" image.</returns>
-        public Image<Rgba32> GetMask() {
-            var mask = GetMaskBase();
-            float threshold = 0.2F;
-            Color sourceColor = Color.White;
-            Color targetColor = Color.Transparent;
-            RecolorBrush brush2 = new RecolorBrush(sourceColor, targetColor, threshold);
-            // var topGrad = new RadialGradientBrush(new PointF(mask.Width/2, mask.Height/2), mask.Height/2, GradientRepetitionMode.None, new ColorStop(0.25F, Color.Transparent), new ColorStop(1, Color.White));
-            // var maskGrad = new RadialGradientBrush(new PointF(mask.Width/2, mask.Height/2), mask.Height/2, GradientRepetitionMode.None, new ColorStop(0F, Color.Black), new ColorStop(0.8F, Color.Black), new ColorStop(0.9F, Color.ParseHex("#00000080")), new ColorStop(1F, Color.Transparent));
-            var landscape = mask.Width > mask.Height;
-            var axisEnd = landscape
-                ? new PointF(mask.Width, mask.Height/2)
-                : new PointF(mask.Width/2, mask.Height);
-            var ratio = landscape
-                ? (float)mask.Width/mask.Height
-                : (float)mask.Height/mask.Width;
-            var stops = new ColorStop[] {
-                new ColorStop(0F, Color.Black), new ColorStop(0.66F, Color.Black), new ColorStop(1F, Color.Transparent)
-            };
-            if (ratio < 0.8 || ratio > 1.2) {
             // if (ratio > 0) {
-                var grads = GetOverlapGradients(mask, stops);
-                mask.Mutate<Rgba32>(x => {
-                    foreach (var grad in grads)
-                    {
-                        x.Fill(grad);
-                    }
-                });
-            } else {
-                var ellGrad = new EllipticGradientBrush(new PointF(mask.Width/2, mask.Height/2), axisEnd, 1F/ratio, GradientRepetitionMode.None, stops);
-                mask.Mutate(x => {
-                    x.Fill(ellGrad);
-                });
-            }
-            
-            return mask;
-        }
-
-        private List<Brush> GetSquareGradients(Image<Rgba32> mask, ColorStop[] stops) {
-            var top = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, 0), GradientRepetitionMode.DontFill, stops);
-            return new List<Brush> {top};
-            // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
-            // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
-            // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);
-            // return new List<IBrush> {top, left, bottom, right};
-
-        }
-
-        private List<Brush> GetOverlapGradients(Image<Rgba32> mask, ColorStop[] stops) {
-            var topCenter = new PointF(mask.Width/2, (mask.Height/4));
-            var topEnd = new PointF(mask.Width, topCenter.Y);
-            var topRatio = (topEnd.X-topCenter.X)/(mask.Height/4F);
-            var top = new EllipticGradientBrush(topCenter, topEnd, 1/topRatio, GradientRepetitionMode.DontFill, stops);
-
-            var lCenter = new PointF((mask.Width/4F), mask.Height/2F);
-            var lEnd = new PointF(lCenter.X, mask.Height);
-            var lRatio = (lEnd.Y-lCenter.Y)/(mask.Width/4F);
-            var left = new EllipticGradientBrush(lCenter, lEnd, 1/lRatio, GradientRepetitionMode.DontFill, stops);
-
-            var btCenter = new PointF(mask.Width/2, (mask.Height/4)*3);
-            var bEnd = new PointF(mask.Width, btCenter.Y);
-            var bRatio = (bEnd.X-btCenter.X)/(mask.Height/4F);
-            var bottom = new EllipticGradientBrush(btCenter, bEnd, 1/bRatio, GradientRepetitionMode.DontFill, stops);
-
-            var rCenter = new PointF((mask.Width/4F)*3F, mask.Height/2F);
-            var rEnd = new PointF(rCenter.X, mask.Height);
-            var rRatio = (rEnd.Y-rCenter.Y)/(mask.Width/4F);
-            var right = new EllipticGradientBrush(rCenter, rEnd, 1/rRatio, GradientRepetitionMode.DontFill, stops);
-
-            var cCenter = new PointF(mask.Width/2F, (mask.Height/2F));
-            var cEnd = new PointF(mask.Width, mask.Height/2F);
-            var cRatio = (cEnd.X-cCenter.X)/(mask.Height/2F);
-            var center = new EllipticGradientBrush(cCenter, cEnd, 1/cRatio, GradientRepetitionMode.DontFill, stops);
-
-            return new List<Brush> {top, left, bottom, right, center};
-            // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
-            // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
-            // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);
-            // return new List<IBrush> {top, left, bottom, right};
-
-        }
-
-        /// <summary>
-        /// Masks the provided image with a basic transparency gradient mask.
-        /// </summary>
-        /// <param name="image">The image to be masked. Must be smaller than the mask. Will not be modified.</param>
-        /// <returns>A new image object with the provided image masked.</returns>
-        public Image<Rgba32> GetMaskedImage(Image image) {
-            var mask = GetMask();
-            var r = mask.Clone(x => x.DrawImage(image, _options));
-            return r;
-        }
-
-        /// <summary>
-        /// Directly draws a partial image on to another image, masking the partial image first.
-        /// </summary>
-        /// <param name="inputImage">The "base" image.</param>
-        /// <param name="censor">The partial image to be drawn on to the main image.</param>
-        /// <typeparam name="T">The type of the base image.</typeparam>
-        /// <returns>The original base image, mutated to include the partial image, blended with a mask.</returns>
-        public T DrawMaskedEffect<T>(T inputImage, Image censor) where T : Image {
-            var masked = GetMaskedImage(censor);
-            inputImage.Mutate(x => {
-                    x.DrawImage(masked, new Point(Convert.ToInt32(this._box.X-this._padding), Convert.ToInt32(this._box.Y-this._padding)), 1);
-                });
-            return inputImage;
-        }
-
-        public Action<IImageProcessingContext> GetMutation(Image censor) {
-            var masked = GetMaskedImage(censor);
-            return (x => {
-                x.DrawImage(masked, new Point(Convert.ToInt32(this._box.X-this._padding), Convert.ToInt32(this._box.Y-this._padding)), 1);
+            var grads = GetOverlapGradients(mask, stops);
+            mask.Mutate<Rgba32>(x =>
+            {
+                foreach (var grad in grads)
+                {
+                    x.Fill(grad);
+                }
             });
         }
+        else
+        {
+            var ellGrad = new EllipticGradientBrush(new PointF(mask.Width / 2, mask.Height / 2), axisEnd, 1F / ratio, GradientRepetitionMode.None, stops);
+            mask.Mutate(x =>
+            {
+                x.Fill(ellGrad);
+            });
+        }
+
+        return mask;
+    }
+
+    private List<Brush> GetSquareGradients(Image<Rgba32> mask, ColorStop[] stops)
+    {
+        var top = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width / 2, 0), GradientRepetitionMode.DontFill, stops);
+        return new List<Brush> { top };
+        // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
+        // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
+        // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);
+        // return new List<IBrush> {top, left, bottom, right};
+
+    }
+
+    private List<Brush> GetOverlapGradients(Image<Rgba32> mask, ColorStop[] stops)
+    {
+        var topCenter = new PointF(mask.Width / 2, (mask.Height / 4));
+        var topEnd = new PointF(mask.Width, topCenter.Y);
+        var topRatio = (topEnd.X - topCenter.X) / (mask.Height / 4F);
+        var top = new EllipticGradientBrush(topCenter, topEnd, 1 / topRatio, GradientRepetitionMode.DontFill, stops);
+
+        var lCenter = new PointF((mask.Width / 4F), mask.Height / 2F);
+        var lEnd = new PointF(lCenter.X, mask.Height);
+        var lRatio = (lEnd.Y - lCenter.Y) / (mask.Width / 4F);
+        var left = new EllipticGradientBrush(lCenter, lEnd, 1 / lRatio, GradientRepetitionMode.DontFill, stops);
+
+        var btCenter = new PointF(mask.Width / 2, (mask.Height / 4) * 3);
+        var bEnd = new PointF(mask.Width, btCenter.Y);
+        var bRatio = (bEnd.X - btCenter.X) / (mask.Height / 4F);
+        var bottom = new EllipticGradientBrush(btCenter, bEnd, 1 / bRatio, GradientRepetitionMode.DontFill, stops);
+
+        var rCenter = new PointF((mask.Width / 4F) * 3F, mask.Height / 2F);
+        var rEnd = new PointF(rCenter.X, mask.Height);
+        var rRatio = (rEnd.Y - rCenter.Y) / (mask.Width / 4F);
+        var right = new EllipticGradientBrush(rCenter, rEnd, 1 / rRatio, GradientRepetitionMode.DontFill, stops);
+
+        var cCenter = new PointF(mask.Width / 2F, (mask.Height / 2F));
+        var cEnd = new PointF(mask.Width, mask.Height / 2F);
+        var cRatio = (cEnd.X - cCenter.X) / (mask.Height / 2F);
+        var center = new EllipticGradientBrush(cCenter, cEnd, 1 / cRatio, GradientRepetitionMode.DontFill, stops);
+
+        return new List<Brush> { top, left, bottom, right, center };
+        // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
+        // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
+        // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);
+        // return new List<IBrush> {top, left, bottom, right};
+
+    }
+
+    /// <summary>
+    /// Masks the provided image with a basic transparency gradient mask.
+    /// </summary>
+    /// <param name="image">The image to be masked. Must be smaller than the mask. Will not be modified.</param>
+    /// <returns>A new image object with the provided image masked.</returns>
+    public Image<Rgba32> GetMaskedImage(Image image)
+    {
+        var mask = GetMask();
+        var r = mask.Clone(x => x.DrawImage(image, _options));
+        return r;
+    }
+
+    /// <summary>
+    /// Directly draws a partial image on to another image, masking the partial image first.
+    /// </summary>
+    /// <param name="inputImage">The "base" image.</param>
+    /// <param name="censor">The partial image to be drawn on to the main image.</param>
+    /// <typeparam name="T">The type of the base image.</typeparam>
+    /// <returns>The original base image, mutated to include the partial image, blended with a mask.</returns>
+    public T DrawMaskedEffect<T>(T inputImage, Image censor) where T : Image
+    {
+        var masked = GetMaskedImage(censor);
+        inputImage.Mutate(x =>
+        {
+            x.DrawImage(masked, new Point(Convert.ToInt32(this._box.X - this._padding), Convert.ToInt32(this._box.Y - this._padding)), 1);
+        });
+        return inputImage;
+    }
+
+    public Action<IImageProcessingContext> GetMutation(Image censor)
+    {
+        var masked = GetMaskedImage(censor);
+        return (x =>
+        {
+            x.DrawImage(masked, new Point(Convert.ToInt32(this._box.X - this._padding), Convert.ToInt32(this._box.Y - this._padding)), 1);
+        });
     }
 }

--- a/src/CensorCore/Censoring/EffectMask.cs
+++ b/src/CensorCore/Censoring/EffectMask.cs
@@ -63,7 +63,7 @@ namespace CensorCore.Censoring
             if (ratio < 0.8 || ratio > 1.2) {
             // if (ratio > 0) {
                 var grads = GetOverlapGradients(mask, stops);
-                mask.Mutate(x => {
+                mask.Mutate<Rgba32>(x => {
                     foreach (var grad in grads)
                     {
                         x.Fill(grad);
@@ -79,9 +79,9 @@ namespace CensorCore.Censoring
             return mask;
         }
 
-        private List<IBrush> GetSquareGradients(Image<Rgba32> mask, ColorStop[] stops) {
+        private List<Brush> GetSquareGradients(Image<Rgba32> mask, ColorStop[] stops) {
             var top = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, 0), GradientRepetitionMode.DontFill, stops);
-            return new List<IBrush> {top};
+            return new List<Brush> {top};
             // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
             // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
             // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);
@@ -89,7 +89,7 @@ namespace CensorCore.Censoring
 
         }
 
-        private List<IBrush> GetOverlapGradients(Image<Rgba32> mask, ColorStop[] stops) {
+        private List<Brush> GetOverlapGradients(Image<Rgba32> mask, ColorStop[] stops) {
             var topCenter = new PointF(mask.Width/2, (mask.Height/4));
             var topEnd = new PointF(mask.Width, topCenter.Y);
             var topRatio = (topEnd.X-topCenter.X)/(mask.Height/4F);
@@ -115,7 +115,7 @@ namespace CensorCore.Censoring
             var cRatio = (cEnd.X-cCenter.X)/(mask.Height/2F);
             var center = new EllipticGradientBrush(cCenter, cEnd, 1/cRatio, GradientRepetitionMode.DontFill, stops);
 
-            return new List<IBrush> {top, left, bottom, right, center};
+            return new List<Brush> {top, left, bottom, right, center};
             // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
             // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
             // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);

--- a/src/CensorCore/Censoring/Features/FacialFeaturesService.cs
+++ b/src/CensorCore/Censoring/Features/FacialFeaturesService.cs
@@ -3,92 +3,102 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Processing;
 
-namespace CensorCore.Censoring.Features {
-    public class FacialFeaturesService {
-        public FacialFeaturesService(IAssetStore assetStore) {
-            _assetStore = assetStore;
-            var lmModel = GetModelResource();
-            _fileHandler = new ImageSharpHandler(112, 112);
-            var opts = new SessionOptions() {
-                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
-            };
-            var fSession = new InferenceSession(lmModel, opts);
-            var fService = new FaceAIService(fSession, _fileHandler);
-            _fService = fService;
-        }
-        private FaceAIService? _fService;
-        private ImageSharpHandler? _fileHandler;
-        private readonly IAssetStore _assetStore;
+namespace CensorCore.Censoring.Features;
 
-        public Task Ready
+public class FacialFeaturesService
+{
+    public FacialFeaturesService(IAssetStore assetStore)
+    {
+        _assetStore = assetStore;
+        var lmModel = GetModelResource();
+        _fileHandler = new ImageSharpHandler(112, 112);
+        var opts = new SessionOptions()
         {
-            get
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+        };
+        var fSession = new InferenceSession(lmModel, opts);
+        var fService = new FaceAIService(fSession, _fileHandler);
+        _fService = fService;
+    }
+    private FaceAIService? _fService;
+    private ImageSharpHandler? _fileHandler;
+    private readonly IAssetStore _assetStore;
+
+    public Task Ready
+    {
+        get
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public async Task<Dictionary<string, FeatureSet>?> GetFeatures(ImageResult result, Classification faceMatch)
+    {
+        if (_fService != null)
+        {
+
+            var cropRect = faceMatch.Box.ToRectangle().GetPadded(faceMatch.Box.Height / 5, result.ImageData.SourceImage);
+            var extract = result.ImageData.SourceImage.Clone(x => x.Crop(cropRect));
+            float scaleFactor = (float)result.ImageData.SourceImage.Height / extract.Height;
+            using (var ms = new MemoryStream())
             {
-                return Task.CompletedTask;
-            }
-        }
+                extract.Save(ms, JpegFormat.Instance); //while we could match formats here, JPEG is **fast**.
+                var data = ms.ToArray();
+                var landmarks = await _fService.RunModel(data);
+                if (landmarks!.Results.Any())
+                {
+                    var features = new Dictionary<string, FeatureSet>();
+                    var points = landmarks.Results.Select(p =>
+                    {
+                        p.Offset(cropRect.X, cropRect.Y);
+                        return p;
+                    }).ToList();
+                    var left = points[36];
+                    var right = points[45];
 
-        public async Task<Dictionary<string, FeatureSet>?> GetFeatures(ImageResult result, Classification faceMatch) {
-            if (_fService != null) {
+                    var eyePointPairs = new[] {
+                        new[] {points[37], points[41]},
+                        new[] {points[38], points[40]},
+                        new[] {points[43], points[47]},
+                        new[] {points[44], points[46]}};
 
-                var cropRect = faceMatch.Box.ToRectangle().GetPadded(faceMatch.Box.Height / 5, result.ImageData.SourceImage);
-                var extract = result.ImageData.SourceImage.Clone(x => x.Crop(cropRect));
-                float scaleFactor = (float)result.ImageData.SourceImage.Height / extract.Height;
-                using (var ms = new MemoryStream()) {
-                    extract.Save(ms, JpegFormat.Instance); //while we could match formats here, JPEG is **fast**.
-                    var data = ms.ToArray();
-                    var landmarks = await _fService.RunModel(data);
-                    if (landmarks!.Results.Any()) {
-                        var features = new Dictionary<string, FeatureSet>();
-                        var points = landmarks.Results.Select(p =>
-                        {
-                            p.Offset(cropRect.X, cropRect.Y);
-                            return p;
-                        }).ToList();
-                        var left = points[36];
-                        var right = points[45];
+                    var eyeFeature = new FeatureSet(left, right, eyePointPairs.Select(ep => (Start: ep[0], End: ep[1])));
+                    features.Add("EYES_F", eyeFeature);
 
-                        var eyePointPairs = new[] {
-                                    new[] {points[37], points[41]},
-                                    new[] {points[38], points[40]},
-                                    new[] {points[43], points[47]},
-                                    new[] {points[44], points[46]}};
+                    var mouthPairs = new[] {
+                        (Start: points[49], End: points[59]),
+                        (Start: points[50], End: points[58]),
+                        (Start: points[51], End: points[57]),
+                        (Start: points[52], End: points[56]),
+                        (Start: points[53], End: points[55])
+                    };
 
-                        var eyeFeature = new FeatureSet(left, right, eyePointPairs.Select(ep => (Start: ep[0], End: ep[1])));
-                        features.Add("EYES_F", eyeFeature);
-
-                        var mouthPairs = new[] {
-                                            (Start: points[49], End: points[59]),
-                                            (Start: points[50], End: points[58]),
-                                            (Start: points[51], End: points[57]),
-                                            (Start: points[52], End: points[56]),
-                                            (Start: points[53], End: points[55])
-                                        };
-
-                        var mouth = new FeatureSet(points[48], points[54], mouthPairs);
-                        features.Add("MOUTH_F", mouth);
-                        return features;
-                    }
+                    var mouth = new FeatureSet(points[48], points[54], mouthPairs);
+                    features.Add("MOUTH_F", mouth);
+                    return features;
                 }
             }
-            return null;
         }
+        return null;
+    }
 
-        private static byte[]? GetModelResource(System.Reflection.Assembly? assembly = null) {
+    private static byte[]? GetModelResource(System.Reflection.Assembly? assembly = null)
+    {
 
-            var entryAssembly = assembly ?? typeof(FacialFeaturesMiddleware).Assembly;
-            var model = entryAssembly.GetManifestResourceNames();
-            //TODO: this doesn't match right
-            if (model != null && model.Any() && model.FirstOrDefault(r => r.Contains("landmarks") && r.EndsWith(".onnx")) is var modelResource && modelResource != null) {
-                // Console.WriteLine($"reading stream from {modelResource}");
-                using var resourceStream = entryAssembly.GetManifestResourceStream(modelResource);
-                if (resourceStream != null && resourceStream.CanRead) {
-                    using var ms = new MemoryStream();
-                    resourceStream.CopyTo(ms);
-                    return ms.ToArray();
-                }
+        var entryAssembly = assembly ?? typeof(FacialFeaturesMiddleware).Assembly;
+        var model = entryAssembly.GetManifestResourceNames();
+        //TODO: this doesn't match right
+        if (model != null && model.Any() && model.FirstOrDefault(r => r.Contains("landmarks") && r.EndsWith(".onnx")) is var modelResource && modelResource != null)
+        {
+            // Console.WriteLine($"reading stream from {modelResource}");
+            using var resourceStream = entryAssembly.GetManifestResourceStream(modelResource);
+            if (resourceStream != null && resourceStream.CanRead)
+            {
+                using var ms = new MemoryStream();
+                resourceStream.CopyTo(ms);
+                return ms.ToArray();
             }
-            return null;
         }
+        return null;
     }
 }

--- a/src/CensorCore/Censoring/Features/FeatureSet.cs
+++ b/src/CensorCore/Censoring/Features/FeatureSet.cs
@@ -1,63 +1,69 @@
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
 
-namespace CensorCore.Censoring.Features {
-    public class FeatureSet {
-        public Point Left { get; }
+namespace CensorCore.Censoring.Features;
 
-        public FeatureSet(Point left, Point right, IEnumerable<(Point Start, Point End)> brackets) {
-            Left = left;
-            Right = right;
-            Brackets = brackets;
-        }
+public class FeatureSet
+{
+    public Point Left { get; }
 
-        public Point Right { get; }
-        public IEnumerable<(Point Start, Point End)> Brackets { get; }
+    public FeatureSet(Point left, Point right, IEnumerable<(Point Start, Point End)> brackets)
+    {
+        Left = left;
+        Right = right;
+        Brackets = brackets;
+    }
 
-        private float GetLongestBracket() {
-            var lineLengths = Brackets.Select(pair =>
-            {
-                var p1 = pair.Start;
-                var p2 = pair.End;
-                return p1.GetDistanceTo(p2);
-            }).ToList();
-            var longest = lineLengths.Max();
-            return longest;
-        }
+    public Point Right { get; }
+    public IEnumerable<(Point Start, Point End)> Brackets { get; }
 
-        public (float Width, Point Start, Point End) ToLine(float widthFactor = 3F, float lengthFactor = 0.25F) {
-            var longest = GetLongestBracket();
-            var width = (float)longest * widthFactor;
-            var pts = GetOffsetPoints(lengthFactor);
-            return (Width: width, Start: pts.Start, End: pts.End);
-        }
+    private float GetLongestBracket()
+    {
+        var lineLengths = Brackets.Select(pair =>
+        {
+            var p1 = pair.Start;
+            var p2 = pair.End;
+            return p1.GetDistanceTo(p2);
+        }).ToList();
+        var longest = lineLengths.Max();
+        return longest;
+    }
 
-        public BoundingBox ToVirtualBox(float widthFactor = 3F, float lengthFactor = 0.25F) {
-            var longest = GetLongestBracket();
-            var width = (float)longest * widthFactor;
-            var pts = GetOffsetPoints();
-            var offsetLeft = pts.Start;
-            var offsetRight = pts.End;
-            var lineLength = offsetLeft.GetDistanceTo(offsetRight);
-            var midpoint = offsetLeft.GetMidpointBetween(offsetRight);
-            var lineSegment = new LinearLineSegment(offsetLeft, offsetRight);
-            var rect = Rectangle.FromLTRB(
-                Convert.ToInt32(midpoint.X-(lineLength/2)), 
-                Convert.ToInt32(midpoint.Y-(width/2)), 
-                Convert.ToInt32(midpoint.X+(lineLength/2)), 
-                Convert.ToInt32(midpoint.Y+(width/2))
-            );
-            return new BoundingBox(rect.X, rect.Y, rect.X+rect.Width, rect.Y+rect.Height);
-        }
+    public (float Width, Point Start, Point End) ToLine(float widthFactor = 3F, float lengthFactor = 0.25F)
+    {
+        var longest = GetLongestBracket();
+        var width = (float)longest * widthFactor;
+        var pts = GetOffsetPoints(lengthFactor);
+        return (Width: width, Start: pts.Start, End: pts.End);
+    }
 
-        public (Point Start, Point End) GetOffsetPoints(float lengthFactor = 0.25F) {
-            var longest = GetLongestBracket();
-            var lineLength = Left.GetDistanceTo(Right);
-            var offsetRight = new Point(Convert.ToInt32(Math.Abs(Right.X + (Right.X - Left.X) / lineLength * (lineLength * lengthFactor))), Convert.ToInt32(Math.Abs(Right.Y + (Right.Y - Left.Y) / lineLength * (lineLength * 0.33))));
-            var offsetLeft = new Point(Convert.ToInt32(Math.Abs(Left.X - (Right.X - Left.X) / lineLength * (lineLength * lengthFactor))), Convert.ToInt32(Math.Abs(Left.Y - (Right.Y - Left.Y) / lineLength * (lineLength * 0.33))));
-            offsetLeft.Offset(0, Convert.ToInt32(Math.Abs(longest / 2)));
-            offsetRight.Offset(0, Convert.ToInt32(Math.Abs(longest / 2)));
-            return (offsetLeft, offsetRight);
-        }
+    public BoundingBox ToVirtualBox(float widthFactor = 3F, float lengthFactor = 0.25F)
+    {
+        var longest = GetLongestBracket();
+        var width = (float)longest * widthFactor;
+        var pts = GetOffsetPoints();
+        var offsetLeft = pts.Start;
+        var offsetRight = pts.End;
+        var lineLength = offsetLeft.GetDistanceTo(offsetRight);
+        var midpoint = offsetLeft.GetMidpointBetween(offsetRight);
+        var lineSegment = new LinearLineSegment(offsetLeft, offsetRight);
+        var rect = Rectangle.FromLTRB(
+            Convert.ToInt32(midpoint.X - (lineLength / 2)),
+            Convert.ToInt32(midpoint.Y - (width / 2)),
+            Convert.ToInt32(midpoint.X + (lineLength / 2)),
+            Convert.ToInt32(midpoint.Y + (width / 2))
+        );
+        return new BoundingBox(rect.X, rect.Y, rect.X + rect.Width, rect.Y + rect.Height);
+    }
+
+    public (Point Start, Point End) GetOffsetPoints(float lengthFactor = 0.25F)
+    {
+        var longest = GetLongestBracket();
+        var lineLength = Left.GetDistanceTo(Right);
+        var offsetRight = new Point(Convert.ToInt32(Math.Abs(Right.X + (Right.X - Left.X) / lineLength * (lineLength * lengthFactor))), Convert.ToInt32(Math.Abs(Right.Y + (Right.Y - Left.Y) / lineLength * (lineLength * 0.33))));
+        var offsetLeft = new Point(Convert.ToInt32(Math.Abs(Left.X - (Right.X - Left.X) / lineLength * (lineLength * lengthFactor))), Convert.ToInt32(Math.Abs(Left.Y - (Right.Y - Left.Y) / lineLength * (lineLength * 0.33))));
+        offsetLeft.Offset(0, Convert.ToInt32(Math.Abs(longest / 2)));
+        offsetRight.Offset(0, Convert.ToInt32(Math.Abs(longest / 2)));
+        return (offsetLeft, offsetRight);
     }
 }

--- a/src/CensorCore/Censoring/GlobalCensorOptions.cs
+++ b/src/CensorCore/Censoring/GlobalCensorOptions.cs
@@ -1,22 +1,21 @@
-namespace CensorCore.Censoring
-{
-    public class GlobalCensorOptions
-    {
-        public bool? AllowTransformers { get;set; } = true;
-        public float? RelativeCensorScale { get; set; } = 1F;
-        public float? PaddingScale { get; set; } = 1F;
-        public bool? ForcePixelBackground { get; set; } = false;
+namespace CensorCore.Censoring;
 
-        public Dictionary<string, float> ClassStrength {get;set;} = new Dictionary<string, float>();
-        /// <summary>
-        /// This is a kludge solution to a real problem. As such, while it is present (and in use) in
-        /// current versions of CensorCore, you should not rely on it remaining part of the long-term 
-        /// and/or stable API in future. Censoring providers should use this to increase the layers 
-        /// of effects applied to certain match classes;
-        /// </summary>
-        /// <typeparam name="string">The match class to apply to.</typeparam>
-        /// <typeparam name="int">A positive or negative value that will get added to the provider's default layer value.</typeparam>
-        /// <returns></returns>
-        public Dictionary<string, int> LayerModifier {get;set;} = new Dictionary<string, int>();
-    }
+public class GlobalCensorOptions
+{
+    public bool? AllowTransformers { get; set; } = true;
+    public float? RelativeCensorScale { get; set; } = 1F;
+    public float? PaddingScale { get; set; } = 1F;
+    public bool? ForcePixelBackground { get; set; } = false;
+
+    public Dictionary<string, float> ClassStrength { get; set; } = new Dictionary<string, float>();
+    /// <summary>
+    /// This is a kludge solution to a real problem. As such, while it is present (and in use) in
+    /// current versions of CensorCore, you should not rely on it remaining part of the long-term 
+    /// and/or stable API in future. Censoring providers should use this to increase the layers 
+    /// of effects applied to certain match classes;
+    /// </summary>
+    /// <typeparam name="string">The match class to apply to.</typeparam>
+    /// <typeparam name="int">A positive or negative value that will get added to the provider's default layer value.</typeparam>
+    /// <returns></returns>
+    public Dictionary<string, int> LayerModifier { get; set; } = new Dictionary<string, int>();
 }

--- a/src/CensorCore/Censoring/ICensorTypeProvider.cs
+++ b/src/CensorCore/Censoring/ICensorTypeProvider.cs
@@ -2,30 +2,31 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
-namespace CensorCore.Censoring
+namespace CensorCore.Censoring;
+
+/// <summary>
+/// Provider for a given "style" of censoring (i.e. pixelation, blurring).
+/// </summary>
+/// <remarks>
+/// Defaults to handling censor requests with a matching type name. That is, MyMethodProvider will handle requests with a 'mymethod' type.
+/// </remarks>
+public interface ICensorTypeProvider
 {
-    /// <summary>
-    /// Provider for a given "style" of censoring (i.e. pixelation, blurring).
-    /// </summary>
-    /// <remarks>
-    /// Defaults to handling censor requests with a matching type name. That is, MyMethodProvider will handle requests with a 'mymethod' type.
-    /// </remarks>
-    public interface ICensorTypeProvider {
-        bool Supports(string censorType) {
-            var typeName = this.GetType().Name.Replace("Provider", string.Empty);
-            return censorType.Split('?', ':').First().Replace("Provider", string.Empty).Equals(typeName, StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        int Layer { get { return 0;} }
-
-        /// <summary>
-        /// Censors a single classification result in the given image.
-        /// </summary>
-        /// <param name="inputImage">The base image to be censored. This may already have been partially censored by other providers/results.</param>
-        /// <param name="result">The specific classification result to censor.</param>
-        /// <param name="method">The requested method. Since the method will only be called if Supports() returns true, this can be used for additional parameters.</param>
-        /// <param name="level">The censor "level", an integer value between 0 and 20 representing "severity" of the censoring. What this means is style-specific.</param>
-        /// <returns>Either an image to be composited onto the main image (by the provider) or null, if the censoring is already completed.</returns>
-        Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level);
+    bool Supports(string censorType)
+    {
+        var typeName = this.GetType().Name.Replace("Provider", string.Empty);
+        return censorType.Split('?', ':').First().Replace("Provider", string.Empty).Equals(typeName, StringComparison.InvariantCultureIgnoreCase);
     }
+
+    int Layer { get { return 0; } }
+
+    /// <summary>
+    /// Censors a single classification result in the given image.
+    /// </summary>
+    /// <param name="inputImage">The base image to be censored. This may already have been partially censored by other providers/results.</param>
+    /// <param name="result">The specific classification result to censor.</param>
+    /// <param name="method">The requested method. Since the method will only be called if Supports() returns true, this can be used for additional parameters.</param>
+    /// <param name="level">The censor "level", an integer value between 0 and 20 representing "severity" of the censoring. What this means is style-specific.</param>
+    /// <returns>Either an image to be composited onto the main image (by the provider) or null, if the censoring is already completed.</returns>
+    Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level);
 }

--- a/src/CensorCore/Censoring/ICensoringMiddleware.cs
+++ b/src/CensorCore/Censoring/ICensoringMiddleware.cs
@@ -4,16 +4,19 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Processing;
 
-namespace CensorCore.Censoring; 
-public interface ICensoringMiddleware {
+namespace CensorCore.Censoring;
+public interface ICensoringMiddleware
+{
     Task Prepare() => Task.CompletedTask;
     Task<IEnumerable<Classification>?> OnBeforeCensoring(ImageResult image, IResultParser? parser, Action<int, Action<IImageProcessingContext>> addLateMutation);
-    Task OnAfterCensoring(Image image, IResultParser? parser) {
+    Task OnAfterCensoring(Image image, IResultParser? parser)
+    {
         return Task.CompletedTask;
     }
 }
 
-public class GifWatermarkMiddleware : ICensoringMiddleware {
+public class GifWatermarkMiddleware : ICensoringMiddleware
+{
     private readonly FontCollection _fonts;
 
     public GifWatermarkMiddleware(FontCollection? fonts = null)
@@ -21,63 +24,75 @@ public class GifWatermarkMiddleware : ICensoringMiddleware {
         _fonts = fonts ?? CaptionProvider.GetDefaultFontCollection();
     }
 
-    public Task<IEnumerable<Classification>?> OnBeforeCensoring(ImageResult result, IResultParser? parser, Action<int, Action<IImageProcessingContext>> addLateMutation) {
-        if (result.ImageData.Format is SixLabors.ImageSharp.Formats.Gif.GifFormat) {
-                var fontSize = (result.ImageData.SourceImage.Width/10F);
-                var font = _fonts.Families.First().CreateFont(fontSize, FontStyle.Bold);
-                var origin = new Point(Math.Min(5, result.ImageData.SourceImage.Width), Math.Min(5, result.ImageData.SourceImage.Height));
-                RichTextOptions options = new(font) {
-                    Origin = origin, // Set the rendering origin.
-                    WrappingLength = 0, // Greater than zero so we will word wrap at 100 pixels wide
-                    HorizontalAlignment = HorizontalAlignment.Left,
-                    VerticalAlignment = VerticalAlignment.Top,
-                    Font = font
-                };
-                Brush brush = Brushes.Solid(Color.Black);
-                Pen pen = Pens.Solid(Color.White, fontSize/16F);
-                addLateMutation(10, x => x.DrawText(options, "GIF", brush, pen));
+    public Task<IEnumerable<Classification>?> OnBeforeCensoring(ImageResult result, IResultParser? parser, Action<int, Action<IImageProcessingContext>> addLateMutation)
+    {
+        if (result.ImageData.Format is SixLabors.ImageSharp.Formats.Gif.GifFormat)
+        {
+            var fontSize = (result.ImageData.SourceImage.Width / 10F);
+            var font = _fonts.Families.First().CreateFont(fontSize, FontStyle.Bold);
+            var origin = new Point(Math.Min(5, result.ImageData.SourceImage.Width), Math.Min(5, result.ImageData.SourceImage.Height));
+            RichTextOptions options = new(font)
+            {
+                Origin = origin, // Set the rendering origin.
+                WrappingLength = 0, // Greater than zero so we will word wrap at 100 pixels wide
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Top,
+                Font = font
+            };
+            Brush brush = Brushes.Solid(Color.Black);
+            Pen pen = Pens.Solid(Color.White, fontSize / 16F);
+            addLateMutation(10, x => x.DrawText(options, "GIF", brush, pen));
         }
         return Task.FromResult<IEnumerable<Classification>?>(null);
     }
 }
 
-public class FacialFeaturesMiddleware : ICensoringMiddleware {
+public class FacialFeaturesMiddleware : ICensoringMiddleware
+{
     private readonly FontCollection _fonts;
     private readonly IAssetStore _assetStore;
     private FacialFeaturesService _faceService;
 
-    public FacialFeaturesMiddleware(IAssetStore assetStore) {
+    public FacialFeaturesMiddleware(IAssetStore assetStore)
+    {
         _fonts = CaptionProvider.GetDefaultFontCollection();
         _assetStore = assetStore;
         _faceService = new FacialFeaturesService(_assetStore);
     }
 
-    public async Task<IEnumerable<Classification>?> OnBeforeCensoring(ImageResult result, IResultParser? parser, Action<int, Action<IImageProcessingContext>> addLateMutation) {
+    public async Task<IEnumerable<Classification>?> OnBeforeCensoring(ImageResult result, IResultParser? parser, Action<int, Action<IImageProcessingContext>> addLateMutation)
+    {
         var eyesResult = parser?.GetOptions("EYES_F", result);
         var mouthOptions = parser?.GetOptions("MOUTH_F", result);
-        if (eyesResult is not null || mouthOptions is not null) {
+        if (eyesResult is not null || mouthOptions is not null)
+        {
             var classifications = new List<Classification>();
-            foreach (var faceMatch in result.Results.Where(r => r.Label.ToLower().Contains("face_f"))) {
+            foreach (var faceMatch in result.Results.Where(r => r.Label.ToLower().Contains("face_f")))
+            {
                 var features = await _faceService.GetFeatures(result, faceMatch);
-                if (features != null && features.TryGetValue("EYES_F", out var eyeFeature) && eyesResult != null) {
-                        var factor = eyesResult.Level.GetScaleFactor(10F);
-                        var rect = eyeFeature.ToVirtualBox(factor * 3F, factor * 0.25F);
-                        var pts = eyeFeature.GetOffsetPoints(factor * 0.25F);
-                        var angle = pts.Start.GetAngleTo(pts.End);
-                        classifications.Add(new Classification(rect, faceMatch.Confidence, "EYES_F") {
-                            SourceAngle = angle,
-                            VirtualBox = true
-                        });
+                if (features != null && features.TryGetValue("EYES_F", out var eyeFeature) && eyesResult != null)
+                {
+                    var factor = eyesResult.Level.GetScaleFactor(10F);
+                    var rect = eyeFeature.ToVirtualBox(factor * 3F, factor * 0.25F);
+                    var pts = eyeFeature.GetOffsetPoints(factor * 0.25F);
+                    var angle = pts.Start.GetAngleTo(pts.End);
+                    classifications.Add(new Classification(rect, faceMatch.Confidence, "EYES_F")
+                    {
+                        SourceAngle = angle,
+                        VirtualBox = true
+                    });
                 }
-                if (features != null && features.TryGetValue("MOUTH_F", out var mouthFeature) && mouthOptions != null) {
-                        var mouthBox = mouthFeature.ToVirtualBox(mouthOptions.Level.GetScaleFactor(10F) * 1.5F);
-                        var pts = mouthFeature.GetOffsetPoints();
-                        var angle = pts.Start.GetAngleTo(pts.End);
-                        classifications.Add(new Classification(mouthBox, faceMatch.Confidence, "MOUTH_F") {
-                            SourceAngle = angle,
-                            VirtualBox = true
-                        });
-                    }
+                if (features != null && features.TryGetValue("MOUTH_F", out var mouthFeature) && mouthOptions != null)
+                {
+                    var mouthBox = mouthFeature.ToVirtualBox(mouthOptions.Level.GetScaleFactor(10F) * 1.5F);
+                    var pts = mouthFeature.GetOffsetPoints();
+                    var angle = pts.Start.GetAngleTo(pts.End);
+                    classifications.Add(new Classification(mouthBox, faceMatch.Confidence, "MOUTH_F")
+                    {
+                        SourceAngle = angle,
+                        VirtualBox = true
+                    });
+                }
             }
             return classifications;
         }

--- a/src/CensorCore/Censoring/ICensoringMiddleware.cs
+++ b/src/CensorCore/Censoring/ICensoringMiddleware.cs
@@ -26,15 +26,15 @@ public class GifWatermarkMiddleware : ICensoringMiddleware {
                 var fontSize = (result.ImageData.SourceImage.Width/10F);
                 var font = _fonts.Families.First().CreateFont(fontSize, FontStyle.Bold);
                 var origin = new Point(Math.Min(5, result.ImageData.SourceImage.Width), Math.Min(5, result.ImageData.SourceImage.Height));
-                TextOptions options = new(font) {
+                RichTextOptions options = new(font) {
                     Origin = origin, // Set the rendering origin.
                     WrappingLength = 0, // Greater than zero so we will word wrap at 100 pixels wide
                     HorizontalAlignment = HorizontalAlignment.Left,
                     VerticalAlignment = VerticalAlignment.Top,
                     Font = font
                 };
-                IBrush brush = Brushes.Solid(Color.Black);
-                IPen pen = Pens.Solid(Color.White, fontSize/16F);
+                Brush brush = Brushes.Solid(Color.Black);
+                Pen pen = Pens.Solid(Color.White, fontSize/16F);
                 addLateMutation(10, x => x.DrawText(options, "GIF", brush, pen));
         }
         return Task.FromResult<IEnumerable<Classification>?>(null);

--- a/src/CensorCore/Censoring/IResultParser.cs
+++ b/src/CensorCore/Censoring/IResultParser.cs
@@ -1,8 +1,10 @@
-namespace CensorCore.Censoring {
-    public interface IResultParser {
-        ImageCensorOptions? GetOptions(Classification result, ImageResult? image = null) {
-            return GetOptions(result.Label, image);
-        }
-        ImageCensorOptions? GetOptions(string label, ImageResult? image = null);
+namespace CensorCore.Censoring;
+
+public interface IResultParser
+{
+    ImageCensorOptions? GetOptions(Classification result, ImageResult? image = null)
+    {
+        return GetOptions(result.Label, image);
     }
+    ImageCensorOptions? GetOptions(string label, ImageResult? image = null);
 }

--- a/src/CensorCore/Censoring/IResultsTransformer.cs
+++ b/src/CensorCore/Censoring/IResultsTransformer.cs
@@ -2,18 +2,22 @@
 
 namespace CensorCore.Censoring;
 
-public interface IResultsTransformer {
+public interface IResultsTransformer
+{
     IEnumerable<Classification> TransformResults(IEnumerable<Classification> matches, IResultParser? parser);
 }
 
-public class CensorScaleTransformer : IResultsTransformer {
+public class CensorScaleTransformer : IResultsTransformer
+{
     private readonly float _scaleFactor;
 
-    public CensorScaleTransformer(GlobalCensorOptions? censorOptions = null) {
+    public CensorScaleTransformer(GlobalCensorOptions? censorOptions = null)
+    {
         _scaleFactor = censorOptions?.RelativeCensorScale ?? 1F;
 
     }
-    public IEnumerable<Classification> TransformResults(IEnumerable<Classification> matches, IResultParser? parser) {
+    public IEnumerable<Classification> TransformResults(IEnumerable<Classification> matches, IResultParser? parser)
+    {
         return matches.Select(m =>
         {
             m.Box = m.Box.ScaleBy(GetScaleAmount(m.Box.Width), GetScaleAmount(m.Box.Height));
@@ -21,42 +25,55 @@ public class CensorScaleTransformer : IResultsTransformer {
         });
     }
 
-    private float GetScaleAmount(int srcValue, bool split = true) {
+    private float GetScaleAmount(int srcValue, bool split = true)
+    {
         return ((srcValue * _scaleFactor) - srcValue) / (split ? 2 : 1);
     }
 }
 
-public class IntersectingMatchMerger : IResultsTransformer {
-    public record CurrentSet(List<Classification> Matches, Rectangle? Merged) {
+public class IntersectingMatchMerger : IResultsTransformer
+{
+    public record CurrentSet(List<Classification> Matches, Rectangle? Merged)
+    {
 
     }
-    public IEnumerable<Classification> TransformResults(IEnumerable<Classification> results, IResultParser? parser) {
+    public IEnumerable<Classification> TransformResults(IEnumerable<Classification> results, IResultParser? parser)
+    {
         var transformed = new List<Classification>();
         var matches = results.GroupBy(r => r.Label).ToList();
-        foreach (var labelGroup in matches) {
+        foreach (var labelGroup in matches)
+        {
             var list = new List<List<Classification>>();
-            if (labelGroup.Count() > 1) {
-                foreach (var rect in labelGroup) {
+            if (labelGroup.Count() > 1)
+            {
+                foreach (var rect in labelGroup)
+                {
                     var intersecting = labelGroup.Where(r => rect.Box.ToRectangle().IntersectsWith(r.Box.ToRectangle())).Where(r => labelGroup.Any(l => !l.Box.ToRectangle().Contains(r.Box.ToRectangle()))).ToList();
                     var isLargest = intersecting.All(r => (rect.GetSize()) >= (r.GetSize()));
-                    if (isLargest) {
+                    if (isLargest)
+                    {
                         list.Add(intersecting.ToList());
                     }
                 }
-                foreach (var set in list.Where(l => l.Any()).Select(l => {
+                foreach (var set in list.Where(l => l.Any()).Select(l =>
+                {
                     var maxConf = l.Max(lcm => lcm.Confidence);
-                    return l.Where(lc => lc.Confidence >= (maxConf*0.75F)).ToList();
-                })) {
-                    if (set.Count() < 2) {
+                    return l.Where(lc => lc.Confidence >= (maxConf * 0.75F)).ToList();
+                }))
+                {
+                    if (set.Count() < 2)
+                    {
                         transformed.Add(set.First());
                     }
-                    else {
+                    else
+                    {
                         var lastMatch = set[0];
                         // Rectangle? main = set[0].Box.ToRectangle();
                         Classification? last = null;
-                        for (int i = 1; i < set.Count; i++) {
+                        for (int i = 1; i < set.Count; i++)
+                        {
                             var current = set[i];
-                            var comparison = last ?? set[i-1];
+                            var comparison = last ?? set[i - 1];
                             var rectA = current.Box.ToRectangle();
                             var rectB = comparison.Box.ToRectangle();
                             var rejections = new List<Predicate<Rectangle>>() {
@@ -68,50 +85,55 @@ public class IntersectingMatchMerger : IResultsTransformer {
                                 rectA.GetCenter().GetAngleTo(rectB.GetCenter()),
                                 rectB.GetCenter().GetAngleTo(rectA.GetCenter())
                                 }.ClosestTo(0F);
-                            if (!rejections.All(r => r(unionRect))) {
-                                var confidence = new[] {last?.Confidence ?? 0F, current.Confidence, comparison?.Confidence ?? 0F}.Max();
+                            if (!rejections.All(r => r(unionRect)))
+                            {
+                                var confidence = new[] { last?.Confidence ?? 0F, current.Confidence, comparison?.Confidence ?? 0F }.Max();
                                 last = new Classification(
-                                        new BoundingBox(unionRect.X, unionRect.Y, unionRect.X + unionRect.Width, unionRect.Y + unionRect.Height), confidence, labelGroup.Key) {
-                                        SourceAngle = closest,
-                                        VirtualBox = false //it might seem like this would be virtual, but the union rect will work either way.
-                                    };
+                                        new BoundingBox(unionRect.X, unionRect.Y, unionRect.X + unionRect.Width, unionRect.Y + unionRect.Height), confidence, labelGroup.Key)
+                                {
+                                    SourceAngle = closest,
+                                    VirtualBox = false //it might seem like this would be virtual, but the union rect will work either way.
+                                };
                                 // i++; //skip an element
                             }
-                            else {
+                            else
+                            {
                                 transformed.Add(comparison);
                                 comparison = null;
                             }
 
                         }
-                        if (last != null) {
+                        if (last != null)
+                        {
                             transformed.Add(last);
                         }
-                    //     var rectA = pair.First().Box.ToRectangle();
-                    //     var rectB = pair.Last().Box.ToRectangle();
-                    //     var rejections = new List<Predicate<Rectangle>>() {
-                    //     r => r.Width > rectA.Width * 2F && r.Width > rectB.Width *2F,
-                    //     r => r.Height > rectA.Height * 2F && r.Height > rectB.Height*2F
-                    // };
-                    //     var unionRect = Rectangle.Union(rectA, rectB);
-                    //     var closest = new[] {
-                    //     rectA.GetCenter().GetAngleTo(rectB.GetCenter()),
-                    //     rectB.GetCenter().GetAngleTo(rectA.GetCenter())
-                    //     }.ClosestTo(0F);
-                    //     if (!rejections.All(r => r(unionRect))) {
-                    //         transformed.Add(
-                    //             new Classification(
-                    //                 new BoundingBox(unionRect.X, unionRect.Y, unionRect.X + unionRect.Width, unionRect.Y + unionRect.Height), Math.Max(pair.First().Confidence, pair.Last().Confidence), labelGroup.Key) {
-                    //                 SourceAngle = closest,
-                    //                 VirtualBox = false //it might seem like this would be virtual, but the union rect will work either way.
-                    //             });
-                    //     }
-                    //     else {
-                    //         transformed.AddRange(pair);
-                    //     }
+                        //     var rectA = pair.First().Box.ToRectangle();
+                        //     var rectB = pair.Last().Box.ToRectangle();
+                        //     var rejections = new List<Predicate<Rectangle>>() {
+                        //     r => r.Width > rectA.Width * 2F && r.Width > rectB.Width *2F,
+                        //     r => r.Height > rectA.Height * 2F && r.Height > rectB.Height*2F
+                        // };
+                        //     var unionRect = Rectangle.Union(rectA, rectB);
+                        //     var closest = new[] {
+                        //     rectA.GetCenter().GetAngleTo(rectB.GetCenter()),
+                        //     rectB.GetCenter().GetAngleTo(rectA.GetCenter())
+                        //     }.ClosestTo(0F);
+                        //     if (!rejections.All(r => r(unionRect))) {
+                        //         transformed.Add(
+                        //             new Classification(
+                        //                 new BoundingBox(unionRect.X, unionRect.Y, unionRect.X + unionRect.Width, unionRect.Y + unionRect.Height), Math.Max(pair.First().Confidence, pair.Last().Confidence), labelGroup.Key) {
+                        //                 SourceAngle = closest,
+                        //                 VirtualBox = false //it might seem like this would be virtual, but the union rect will work either way.
+                        //             });
+                        //     }
+                        //     else {
+                        //         transformed.AddRange(pair);
+                        //     }
                     }
                 }
             }
-            else {
+            else
+            {
                 transformed.AddRange(labelGroup);
             }
             // if (labelGroup.Count() > 1 && labelGroup.All(r => labelGroup.All(l => r.Box.ToRectangle().IntersectsWith(l.Box.ToRectangle()))))

--- a/src/CensorCore/Censoring/ImageCensorOptions.cs
+++ b/src/CensorCore/Censoring/ImageCensorOptions.cs
@@ -1,19 +1,19 @@
-namespace CensorCore.Censoring
+namespace CensorCore.Censoring;
+
+public class ImageCensorOptions
 {
-    public class ImageCensorOptions {
-        public string CensorType {get;set;}
+    public string CensorType { get; set; }
 
-        public ImageCensorOptions(string censorType)
-        {
-            CensorType = censorType;
-        }
-
-        [System.Text.Json.Serialization.JsonConstructor]
-        public ImageCensorOptions(string censorType, int? level) : this(censorType)
-        {
-            Level = level;
-        }
-
-        public int? Level {get;set;}
+    public ImageCensorOptions(string censorType)
+    {
+        CensorType = censorType;
     }
+
+    [System.Text.Json.Serialization.JsonConstructor]
+    public ImageCensorOptions(string censorType, int? level) : this(censorType)
+    {
+        Level = level;
+    }
+
+    public int? Level { get; set; }
 }

--- a/src/CensorCore/Censoring/ImageSharpCensoringProvider.cs
+++ b/src/CensorCore/Censoring/ImageSharpCensoringProvider.cs
@@ -1,132 +1,148 @@
 using System.Diagnostics;
-using CensorCore.Censoring;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Processing;
 
 
 
-namespace CensorCore.Censoring
+namespace CensorCore.Censoring;
+
+public interface ICensoringProvider
 {
-    public interface ICensoringProvider {
-        Task<CensoredImage> CensorImage(ImageResult image, IResultParser? parser = null);
+    Task<CensoredImage> CensorImage(ImageResult image, IResultParser? parser = null);
+}
+
+public class ImageSharpCensoringProvider : ICensoringProvider
+{
+    private readonly IEnumerable<IResultsTransformer> _transformers;
+    private readonly GlobalCensorOptions _options;
+    private readonly IEnumerable<ICensorTypeProvider> _providers;
+    private readonly IEnumerable<ICensoringMiddleware> _middlewares;
+    private readonly IResultParser? _parser;
+
+    public ImageSharpCensoringProvider(IEnumerable<ICensorTypeProvider> providers, IResultParser parser, GlobalCensorOptions? options = null, IEnumerable<IResultsTransformer>? transformers = null, IEnumerable<ICensoringMiddleware>? middlewares = null) : this(providers, options, transformers, middlewares)
+    {
+        _parser = parser;
     }
 
-    public class ImageSharpCensoringProvider : ICensoringProvider {
-        private readonly IEnumerable<IResultsTransformer> _transformers;
-        private readonly GlobalCensorOptions _options;
-        private readonly IEnumerable<ICensorTypeProvider> _providers;
-        private readonly IEnumerable<ICensoringMiddleware> _middlewares;
-        private readonly IResultParser? _parser;
+    public ImageSharpCensoringProvider(IEnumerable<ICensorTypeProvider> providers, GlobalCensorOptions? options = null, IEnumerable<IResultsTransformer>? transformers = null, IEnumerable<ICensoringMiddleware>? middlewares = null)
+    {
+        _transformers = transformers ?? new List<IResultsTransformer>();
+        _options = options ?? new GlobalCensorOptions();
+        _providers = providers;
+        _middlewares = middlewares ?? new List<ICensoringMiddleware>();
+    }
 
-        public ImageSharpCensoringProvider(IEnumerable<ICensorTypeProvider> providers, IResultParser parser, GlobalCensorOptions? options = null, IEnumerable<IResultsTransformer>? transformers = null, IEnumerable<ICensoringMiddleware>? middlewares = null) : this(providers, options, transformers, middlewares) {
-            _parser = parser;
+    public async Task<CensoredImage> CensorImage(ImageResult image, IResultParser? parser = null)
+    {
+        parser = parser ?? this._parser;
+        var img = image.ImageData.SourceImage.Clone();
+        var censorEffects = new Dictionary<int, List<Action<IImageProcessingContext>>>();
+        // var matches = image.Results.GroupBy(r => r.Label).ToList();
+        IEnumerable<Classification> transformedMatches = image.Results;
+
+        foreach (var middleware in _middlewares)
+        {
+            await middleware.Prepare();
         }
-
-        public ImageSharpCensoringProvider(IEnumerable<ICensorTypeProvider> providers, GlobalCensorOptions? options = null, IEnumerable<IResultsTransformer>? transformers = null, IEnumerable<ICensoringMiddleware>? middlewares = null) {
-            _transformers = transformers ?? new List<IResultsTransformer>();
-            _options = options ?? new GlobalCensorOptions();
-            _providers = providers;
-            _middlewares = middlewares ?? new List<ICensoringMiddleware>();
+        if (_transformers.Any() && (_options.AllowTransformers ?? true))
+        {
+            foreach (var transformer in _transformers)
+            {
+                transformedMatches = transformer.TransformResults(transformedMatches, parser);
+            }
         }
-
-        public async Task<CensoredImage> CensorImage(ImageResult image, IResultParser? parser = null) {
-            parser = parser ?? this._parser;
-            var img = image.ImageData.SourceImage.Clone();
-            var censorEffects = new Dictionary<int, List<Action<IImageProcessingContext>>>();
-            // var matches = image.Results.GroupBy(r => r.Label).ToList();
-            IEnumerable<Classification> transformedMatches = image.Results;
-
+        if (_middlewares.Any())
+        {
             foreach (var middleware in _middlewares)
             {
-                await middleware.Prepare();
-            }
-            if (_transformers.Any() && (_options.AllowTransformers ?? true))
-            {
-                foreach (var transformer in _transformers)
+                try
                 {
-                    transformedMatches = transformer.TransformResults(transformedMatches, parser);
-                }
-            }
-            if (_middlewares.Any()) {
-                foreach (var middleware in _middlewares)
-                {
-                    try {
-                        var additionalResults = await middleware.OnBeforeCensoring(image, parser, (i, ctx) => AddCensor(i, null, null, ctx));
-                        if (additionalResults != null) {
-                            transformedMatches = transformedMatches.Concat(additionalResults);
-                        }
-                    } catch {
-                        //ignored
-                    }
-                }
-            }
-            var timer = new Stopwatch();
-            foreach (var match in transformedMatches.OrderBy(r => r.Box.Width * r.Box.Height))
-            {
-                var options = parser?.GetOptions(match, image) ?? new ImageCensorOptions(nameof(BlurProvider)) { Level = 10 };
-                var provider = this._providers.FirstOrDefault(p => p.Supports(options.CensorType ?? string.Empty));
-                if (provider != null)
-                {
-                    timer.Restart();
-                    var censorMutation = await provider.CensorImage(img, match, options.CensorType, options.Level ?? 10);
-                    if (censorMutation != null)
+                    var additionalResults = await middleware.OnBeforeCensoring(image, parser, (i, ctx) => AddCensor(i, null, null, ctx));
+                    if (additionalResults != null)
                     {
-                        AddCensor(provider.Layer, match, options, censorMutation);
-                    }
-                    timer.Stop();
-                    if (timer.Elapsed.TotalSeconds > 1D) {
-                        Console.WriteLine($"WARN: Censoring for {provider.GetType().Name} on {match.Label} took {timer.Elapsed.TotalSeconds}s!");
+                        transformedMatches = transformedMatches.Concat(additionalResults);
                     }
                 }
-            }
-            if (censorEffects.Any()) {
-                img.Mutate(x =>
+                catch
                 {
-                    foreach (var (layer, effects) in censorEffects.OrderBy(k => k.Key))
-                    {
-                        foreach (var effect in effects)
-                        {
-                            effect?.Invoke(x);
-                        }
-                    }
-                });
-            }
-            foreach (var middleware in _middlewares)
-            {
-                try {
-                    await middleware.OnAfterCensoring(img, parser);
-                } catch {
                     //ignored
                 }
             }
-            using (var ms = new MemoryStream())
+        }
+        var timer = new Stopwatch();
+        foreach (var match in transformedMatches.OrderBy(r => r.Box.Width * r.Box.Height))
+        {
+            var options = parser?.GetOptions(match, image) ?? new ImageCensorOptions(nameof(BlurProvider)) { Level = 10 };
+            var provider = this._providers.FirstOrDefault(p => p.Supports(options.CensorType ?? string.Empty));
+            if (provider != null)
             {
-                if (image.ImageData.Format != null) {
-                    var format = image.ImageData.Format;
-                    img.Save(ms, format);
-                    return new CensoredImage(ms.ToArray(), format.DefaultMimeType, img.ToBase64String(format));
-                } else {
-                    img.Save(ms, PngFormat.Instance);
-                    return new CensoredImage(ms.ToArray(), "image/png", img.ToBase64String(PngFormat.Instance));
+                timer.Restart();
+                var censorMutation = await provider.CensorImage(img, match, options.CensorType, options.Level ?? 10);
+                if (censorMutation != null)
+                {
+                    AddCensor(provider.Layer, match, options, censorMutation);
                 }
-                
-            }
-            void AddCensor(int layer, Classification? match, ImageCensorOptions? censor, Action<IImageProcessingContext> mutation) {
-                if (censorEffects != null) {
-                    if (censor?.CensorType != null && _options.LayerModifier.TryGetValue(match?.Label ?? string.Empty, out var mod)) {
-                        layer += mod;
-                    }
-                    if (!censorEffects.ContainsKey(layer)) {
-                        censorEffects[layer] = new List<Action<IImageProcessingContext>>();
-                    }
-                    censorEffects[layer].Add(mutation);
+                timer.Stop();
+                if (timer.Elapsed.TotalSeconds > 1D)
+                {
+                    Console.WriteLine($"WARN: Censoring for {provider.GetType().Name} on {match.Label} took {timer.Elapsed.TotalSeconds}s!");
                 }
             }
         }
+        if (censorEffects.Any())
+        {
+            img.Mutate(x =>
+            {
+                foreach (var (layer, effects) in censorEffects.OrderBy(k => k.Key))
+                {
+                    foreach (var effect in effects)
+                    {
+                        effect?.Invoke(x);
+                    }
+                }
+            });
+        }
+        foreach (var middleware in _middlewares)
+        {
+            try
+            {
+                await middleware.OnAfterCensoring(img, parser);
+            }
+            catch
+            {
+                //ignored
+            }
+        }
+        using (var ms = new MemoryStream())
+        {
+            if (image.ImageData.Format != null)
+            {
+                var format = image.ImageData.Format;
+                img.Save(ms, format);
+                return new CensoredImage(ms.ToArray(), format.DefaultMimeType, img.ToBase64String(format));
+            }
+            else
+            {
+                img.Save(ms, PngFormat.Instance);
+                return new CensoredImage(ms.ToArray(), "image/png", img.ToBase64String(PngFormat.Instance));
+            }
+
+        }
+        void AddCensor(int layer, Classification? match, ImageCensorOptions? censor, Action<IImageProcessingContext> mutation)
+        {
+            if (censorEffects != null)
+            {
+                if (censor?.CensorType != null && _options.LayerModifier.TryGetValue(match?.Label ?? string.Empty, out var mod))
+                {
+                    layer += mod;
+                }
+                if (!censorEffects.ContainsKey(layer))
+                {
+                    censorEffects[layer] = new List<Action<IImageProcessingContext>>();
+                }
+                censorEffects[layer].Add(mutation);
+            }
+        }
     }
-
-
-
-
 }

--- a/src/CensorCore/Censoring/PathEffectMask.cs
+++ b/src/CensorCore/Censoring/PathEffectMask.cs
@@ -5,173 +5,189 @@ using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
-namespace CensorCore.Censoring {
+namespace CensorCore.Censoring;
+
+/// <summary>
+/// A helper class for blending censor methods with the surrounding image. 
+/// </summary>
+public class PathEffectMask
+{
+
+    private readonly Rectangle _rect;
+    private readonly int _padding;
+    private readonly GraphicsOptions _options;
+    private readonly float _angle;
+    private readonly Point _sourceReference;
+    private readonly DrawingOptions _drawing;
+
     /// <summary>
-    /// A helper class for blending censor methods with the surrounding image. 
+    /// Create an instance of the Mask helper for the given bounding box, optionally with padding.
     /// </summary>
-    public class PathEffectMask {
-        
-        private readonly Rectangle _rect;
-        private readonly int _padding;
-        private readonly GraphicsOptions _options;
-        private readonly float _angle;
-        private readonly Point _sourceReference;
-        private readonly DrawingOptions _drawing;
+    /// <param name="box">The bounding box used to create the mask.</param>
+    /// <param name="padding">An optional padding to increase the size of the mask.</param>
+    public PathEffectMask(Rectangle rectangle, float angle, int padding = 1)
+    {
+        this._rect = rectangle;
+        this._padding = padding;
+        this._options = new GraphicsOptions { AlphaCompositionMode = PixelAlphaCompositionMode.SrcIn };
+        this._angle = angle;
+        this._sourceReference = rectangle.GetCenter();
+        // this._drawing = new DrawingOptions() { Transform = Matrix3x2Extensions.CreateRotationDegrees(angle, ((Rectangle)_rect).GetCenter()) };
+        this._drawing = new DrawingOptions();
+    }
 
-        /// <summary>
-        /// Create an instance of the Mask helper for the given bounding box, optionally with padding.
-        /// </summary>
-        /// <param name="box">The bounding box used to create the mask.</param>
-        /// <param name="padding">An optional padding to increase the size of the mask.</param>
-        public PathEffectMask(Rectangle rectangle, float angle, int padding = 1) {
-            this._rect = rectangle;
-            this._padding = padding;
-            this._options = new GraphicsOptions { AlphaCompositionMode = PixelAlphaCompositionMode.SrcIn };
-            this._angle = angle;
-            this._sourceReference = rectangle.GetCenter();
-            // this._drawing = new DrawingOptions() { Transform = Matrix3x2Extensions.CreateRotationDegrees(angle, ((Rectangle)_rect).GetCenter()) };
-            this._drawing = new DrawingOptions();
+    public RectangleF GetBounds(Image? sourceImage = null)
+    {
+        if (sourceImage == null)
+        {
+            return new RectangularPolygon(_rect.GetPadded(_padding)).RotateDegree(_angle).Bounds;
         }
-
-        public RectangleF GetBounds(Image? sourceImage = null) {
-            if (sourceImage == null) {
-                return new RectangularPolygon(_rect.GetPadded(_padding)).RotateDegree(_angle).Bounds;
-            } else {
-                return new RectangularPolygon(_rect.GetPadded(_padding)).RotateDegree(_angle).Bounds.FitToBounds(sourceImage);
-            }
+        else
+        {
+            return new RectangularPolygon(_rect.GetPadded(_padding)).RotateDegree(_angle).Bounds.FitToBounds(sourceImage);
         }
+    }
 
-        private Image<Rgba32> GetMaskBase() {
+    private Image<Rgba32> GetMaskBase()
+    {
 
-            var box = (Rectangle)_rect;
-            return new Image<Rgba32>(box.Width + (this._padding * 2), box.Height + (this._padding * 2), Rgba32.ParseHex("#00000000"));
-        }
+        var box = (Rectangle)_rect;
+        return new Image<Rgba32>(box.Width + (this._padding * 2), box.Height + (this._padding * 2), Rgba32.ParseHex("#00000000"));
+    }
 
-        /// <summary>
-        /// Gets the mask image to apply to an image.
-        /// </summary>
-        /// <returns>An image of the mask. Contains *only* the mask, not the "real" image.</returns>
-        public Image<Rgba32> GetMask(Rectangle? bounds = null) {
-            var maskBase = GetMaskBase();
-            var mask = maskBase;
-            // var topGrad = new RadialGradientBrush(new PointF(mask.Width/2, mask.Height/2), mask.Height/2, GradientRepetitionMode.None, new ColorStop(0.25F, Color.Transparent), new ColorStop(1, Color.White));
-            // var maskGrad = new RadialGradientBrush(new PointF(mask.Width/2, mask.Height/2), mask.Height/2, GradientRepetitionMode.None, new ColorStop(0F, Color.Black), new ColorStop(0.8F, Color.Black), new ColorStop(0.9F, Color.ParseHex("#00000080")), new ColorStop(1F, Color.Transparent));
-            var landscape = mask.Width > mask.Height;
-            var axisEnd = landscape
-                ? new PointF(mask.Width, mask.Height / 2)
-                : new PointF(mask.Width / 2, mask.Height);
-            var ratio = landscape
-                ? (float)mask.Width / mask.Height
-                : (float)mask.Height / mask.Width;
-            var stops = new ColorStop[] {
-                new ColorStop(0F, Color.Black), new ColorStop(0.66F, Color.Black), new ColorStop(1F, Color.Transparent)
-            };
-            if (ratio < 0.8 || ratio > 1.2) {
-                // if (ratio > 0) {
-                var grads = GetOverlapGradients(mask, stops);
-                maskBase.Mutate(x =>
-                {
-                    foreach (var grad in grads) {
-                        x.Fill(_drawing, grad);
-                    }
-                });
-            }
-            else {
-                var ellGrad = new EllipticGradientBrush(new PointF(mask.Width / 2, mask.Height / 2), axisEnd, 1F / ratio, GradientRepetitionMode.None, stops);
-                maskBase.Mutate(x =>
-                {
-                    x.Fill(_drawing, ellGrad);
-                });
-            }
-            var affineBuilder = new AffineTransformBuilder();
-
-            var ctr = _rect.GetCenter();
-            affineBuilder.PrependTranslation(new Vector2(ctr.X, ctr.Y));
-            affineBuilder.PrependRotationDegrees(_angle);
-            affineBuilder.AppendTranslation(new Vector2(-ctr.X, -ctr.Y));
-            maskBase.Mutate(m => m.Transform(affineBuilder));
-            return maskBase;
-        }
-
-        private List<Brush> GetSquareGradients(Image<Rgba32> mask, ColorStop[] stops) {
-            var top = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width / 2, 0), GradientRepetitionMode.DontFill, stops);
-            return new List<Brush> { top };
-            // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
-            // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
-            // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);
-            // return new List<IBrush> {top, left, bottom, right};
-
-        }
-
-        private List<Brush> GetOverlapGradients(Image mask, ColorStop[] stops) {
-            var topCenter = new PointF(mask.Width / 2, (mask.Height / 4));
-            var topEnd = new PointF(mask.Width, topCenter.Y);
-            var topRatio = (topEnd.X - topCenter.X) / (mask.Height / 4F);
-            var top = new EllipticGradientBrush(topCenter, topEnd, 1 / topRatio, GradientRepetitionMode.DontFill, stops);
-
-            var lCenter = new PointF((mask.Width / 4F), mask.Height / 2F);
-            var lEnd = new PointF(lCenter.X, mask.Height);
-            var lRatio = (lEnd.Y - lCenter.Y) / (mask.Width / 4F);
-            var left = new EllipticGradientBrush(lCenter, lEnd, 1 / lRatio, GradientRepetitionMode.DontFill, stops);
-
-            var btCenter = new PointF(mask.Width / 2, (mask.Height / 4) * 3);
-            var bEnd = new PointF(mask.Width, btCenter.Y);
-            var bRatio = (bEnd.X - btCenter.X) / (mask.Height / 4F);
-            var bottom = new EllipticGradientBrush(btCenter, bEnd, 1 / bRatio, GradientRepetitionMode.DontFill, stops);
-
-            var rCenter = new PointF((mask.Width / 4F) * 3F, mask.Height / 2F);
-            var rEnd = new PointF(rCenter.X, mask.Height);
-            var rRatio = (rEnd.Y - rCenter.Y) / (mask.Width / 4F);
-            var right = new EllipticGradientBrush(rCenter, rEnd, 1 / rRatio, GradientRepetitionMode.DontFill, stops);
-
-            var cCenter = new PointF(mask.Width / 2F, (mask.Height / 2F));
-            var cEnd = new PointF(mask.Width, mask.Height / 2F);
-            var cRatio = (cEnd.X - cCenter.X) / (mask.Height / 2F);
-            var center = new EllipticGradientBrush(cCenter, cEnd, 1 / cRatio, GradientRepetitionMode.DontFill, stops);
-
-            return new List<Brush> { top, left, bottom, right, center };
-        }
-
-        /// <summary>
-        /// Masks the provided image with a basic transparency gradient mask.
-        /// </summary>
-        /// <param name="image">The image to be masked. Must be smaller than the mask. Will not be modified.</param>
-        /// <returns>A new image object with the provided image masked.</returns>
-        public Image<Rgba32> GetMaskedImage(Image image) {
-            var mask = GetMask();
-            var r = mask.Clone(x => x.DrawImage(image, _options));
-            return r;
-        }
-
-        /// <summary>
-        /// Directly draws a partial image on to another image, masking the partial image first.
-        /// </summary>
-        /// <param name="inputImage">The "base" image.</param>
-        /// <param name="censor">The partial image to be drawn on to the main image.</param>
-        /// <typeparam name="T">The type of the base image.</typeparam>
-        /// <returns>The original base image, mutated to include the partial image, blended with a mask.</returns>
-        public T DrawMaskedEffect<T>(T inputImage, Image censor) where T : Image {
-            var masked = GetMaskedImage(censor);
-            inputImage.Mutate(x =>
+    /// <summary>
+    /// Gets the mask image to apply to an image.
+    /// </summary>
+    /// <returns>An image of the mask. Contains *only* the mask, not the "real" image.</returns>
+    public Image<Rgba32> GetMask(Rectangle? bounds = null)
+    {
+        var maskBase = GetMaskBase();
+        var mask = maskBase;
+        // var topGrad = new RadialGradientBrush(new PointF(mask.Width/2, mask.Height/2), mask.Height/2, GradientRepetitionMode.None, new ColorStop(0.25F, Color.Transparent), new ColorStop(1, Color.White));
+        // var maskGrad = new RadialGradientBrush(new PointF(mask.Width/2, mask.Height/2), mask.Height/2, GradientRepetitionMode.None, new ColorStop(0F, Color.Black), new ColorStop(0.8F, Color.Black), new ColorStop(0.9F, Color.ParseHex("#00000080")), new ColorStop(1F, Color.Transparent));
+        var landscape = mask.Width > mask.Height;
+        var axisEnd = landscape
+            ? new PointF(mask.Width, mask.Height / 2)
+            : new PointF(mask.Width / 2, mask.Height);
+        var ratio = landscape
+            ? (float)mask.Width / mask.Height
+            : (float)mask.Height / mask.Width;
+        var stops = new ColorStop[] {
+            new ColorStop(0F, Color.Black), new ColorStop(0.66F, Color.Black), new ColorStop(1F, Color.Transparent)
+        };
+        if (ratio < 0.8 || ratio > 1.2)
+        {
+            // if (ratio > 0) {
+            var grads = GetOverlapGradients(mask, stops);
+            maskBase.Mutate(x =>
             {
-                x.DrawImage(masked, new Point(Convert.ToInt32(this._rect.X - this._padding), Convert.ToInt32(this._rect.Y - this._padding)), 1);
-            });
-            return inputImage;
-        }
-
-        public Action<IImageProcessingContext> GetMutation(Image censor) {
-            var masked = GetMaskedImage(censor);
-            var deltaX = (masked.Width - _rect.Width)/2;
-            var deltaY = (masked.Height - _rect.Height)/2;
-            return (x =>
-            {
-                x.DrawImage(
-                    masked, 
-                    new Point(
-                        Convert.ToInt32(Math.Max(this._rect.X - deltaX, 0)), 
-                        Convert.ToInt32(Math.Max(this._rect.Y - deltaY, 0))
-                    ), 1);
+                foreach (var grad in grads)
+                {
+                    x.Fill(_drawing, grad);
+                }
             });
         }
+        else
+        {
+            var ellGrad = new EllipticGradientBrush(new PointF(mask.Width / 2, mask.Height / 2), axisEnd, 1F / ratio, GradientRepetitionMode.None, stops);
+            maskBase.Mutate(x =>
+            {
+                x.Fill(_drawing, ellGrad);
+            });
+        }
+        var affineBuilder = new AffineTransformBuilder();
+
+        var ctr = _rect.GetCenter();
+        affineBuilder.PrependTranslation(new Vector2(ctr.X, ctr.Y));
+        affineBuilder.PrependRotationDegrees(_angle);
+        affineBuilder.AppendTranslation(new Vector2(-ctr.X, -ctr.Y));
+        maskBase.Mutate(m => m.Transform(affineBuilder));
+        return maskBase;
+    }
+
+    private List<Brush> GetSquareGradients(Image<Rgba32> mask, ColorStop[] stops)
+    {
+        var top = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width / 2, 0), GradientRepetitionMode.DontFill, stops);
+        return new List<Brush> { top };
+        // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
+        // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
+        // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);
+        // return new List<IBrush> {top, left, bottom, right};
+
+    }
+
+    private List<Brush> GetOverlapGradients(Image mask, ColorStop[] stops)
+    {
+        var topCenter = new PointF(mask.Width / 2, (mask.Height / 4));
+        var topEnd = new PointF(mask.Width, topCenter.Y);
+        var topRatio = (topEnd.X - topCenter.X) / (mask.Height / 4F);
+        var top = new EllipticGradientBrush(topCenter, topEnd, 1 / topRatio, GradientRepetitionMode.DontFill, stops);
+
+        var lCenter = new PointF((mask.Width / 4F), mask.Height / 2F);
+        var lEnd = new PointF(lCenter.X, mask.Height);
+        var lRatio = (lEnd.Y - lCenter.Y) / (mask.Width / 4F);
+        var left = new EllipticGradientBrush(lCenter, lEnd, 1 / lRatio, GradientRepetitionMode.DontFill, stops);
+
+        var btCenter = new PointF(mask.Width / 2, (mask.Height / 4) * 3);
+        var bEnd = new PointF(mask.Width, btCenter.Y);
+        var bRatio = (bEnd.X - btCenter.X) / (mask.Height / 4F);
+        var bottom = new EllipticGradientBrush(btCenter, bEnd, 1 / bRatio, GradientRepetitionMode.DontFill, stops);
+
+        var rCenter = new PointF((mask.Width / 4F) * 3F, mask.Height / 2F);
+        var rEnd = new PointF(rCenter.X, mask.Height);
+        var rRatio = (rEnd.Y - rCenter.Y) / (mask.Width / 4F);
+        var right = new EllipticGradientBrush(rCenter, rEnd, 1 / rRatio, GradientRepetitionMode.DontFill, stops);
+
+        var cCenter = new PointF(mask.Width / 2F, (mask.Height / 2F));
+        var cEnd = new PointF(mask.Width, mask.Height / 2F);
+        var cRatio = (cEnd.X - cCenter.X) / (mask.Height / 2F);
+        var center = new EllipticGradientBrush(cCenter, cEnd, 1 / cRatio, GradientRepetitionMode.DontFill, stops);
+
+        return new List<Brush> { top, left, bottom, right, center };
+    }
+
+    /// <summary>
+    /// Masks the provided image with a basic transparency gradient mask.
+    /// </summary>
+    /// <param name="image">The image to be masked. Must be smaller than the mask. Will not be modified.</param>
+    /// <returns>A new image object with the provided image masked.</returns>
+    public Image<Rgba32> GetMaskedImage(Image image)
+    {
+        var mask = GetMask();
+        var r = mask.Clone(x => x.DrawImage(image, _options));
+        return r;
+    }
+
+    /// <summary>
+    /// Directly draws a partial image on to another image, masking the partial image first.
+    /// </summary>
+    /// <param name="inputImage">The "base" image.</param>
+    /// <param name="censor">The partial image to be drawn on to the main image.</param>
+    /// <typeparam name="T">The type of the base image.</typeparam>
+    /// <returns>The original base image, mutated to include the partial image, blended with a mask.</returns>
+    public T DrawMaskedEffect<T>(T inputImage, Image censor) where T : Image
+    {
+        var masked = GetMaskedImage(censor);
+        inputImage.Mutate(x =>
+        {
+            x.DrawImage(masked, new Point(Convert.ToInt32(this._rect.X - this._padding), Convert.ToInt32(this._rect.Y - this._padding)), 1);
+        });
+        return inputImage;
+    }
+
+    public Action<IImageProcessingContext> GetMutation(Image censor)
+    {
+        var masked = GetMaskedImage(censor);
+        var deltaX = (masked.Width - _rect.Width) / 2;
+        var deltaY = (masked.Height - _rect.Height) / 2;
+        return (x =>
+        {
+            x.DrawImage(
+                masked,
+                new Point(
+                    Convert.ToInt32(Math.Max(this._rect.X - deltaX, 0)),
+                    Convert.ToInt32(Math.Max(this._rect.Y - deltaY, 0))
+                ), 1);
+        });
     }
 }

--- a/src/CensorCore/Censoring/PathEffectMask.cs
+++ b/src/CensorCore/Censoring/PathEffectMask.cs
@@ -93,9 +93,9 @@ namespace CensorCore.Censoring {
             return maskBase;
         }
 
-        private List<IBrush> GetSquareGradients(Image<Rgba32> mask, ColorStop[] stops) {
+        private List<Brush> GetSquareGradients(Image<Rgba32> mask, ColorStop[] stops) {
             var top = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width / 2, 0), GradientRepetitionMode.DontFill, stops);
-            return new List<IBrush> { top };
+            return new List<Brush> { top };
             // var left = new LinearGradientBrush(mask.GetCenter(), new PointF(0, mask.Height/2), GradientRepetitionMode.DontFill, stops);
             // var bottom = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width/2, mask.Height), GradientRepetitionMode.DontFill, stops);
             // var right = new LinearGradientBrush(mask.GetCenter(), new PointF(mask.Width, mask.Height/2), GradientRepetitionMode.DontFill, stops);
@@ -103,7 +103,7 @@ namespace CensorCore.Censoring {
 
         }
 
-        private List<IBrush> GetOverlapGradients(Image mask, ColorStop[] stops) {
+        private List<Brush> GetOverlapGradients(Image mask, ColorStop[] stops) {
             var topCenter = new PointF(mask.Width / 2, (mask.Height / 4));
             var topEnd = new PointF(mask.Width, topCenter.Y);
             var topRatio = (topEnd.X - topCenter.X) / (mask.Height / 4F);
@@ -129,7 +129,7 @@ namespace CensorCore.Censoring {
             var cRatio = (cEnd.X - cCenter.X) / (mask.Height / 2F);
             var center = new EllipticGradientBrush(cCenter, cEnd, 1 / cRatio, GradientRepetitionMode.DontFill, stops);
 
-            return new List<IBrush> { top, left, bottom, right, center };
+            return new List<Brush> { top, left, bottom, right, center };
         }
 
         /// <summary>

--- a/src/CensorCore/Censoring/PixelationProvider.cs
+++ b/src/CensorCore/Censoring/PixelationProvider.cs
@@ -2,34 +2,33 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
-namespace CensorCore.Censoring
+namespace CensorCore.Censoring;
+
+public class PixelationProvider : ICensorTypeProvider
 {
-    public class PixelationProvider : ICensorTypeProvider
+    private readonly GlobalCensorOptions _globalOpts = new GlobalCensorOptions();
+    public PixelationProvider() { }
+    public PixelationProvider(GlobalCensorOptions globalOpts)
     {
-        private readonly GlobalCensorOptions _globalOpts = new GlobalCensorOptions();
-        public PixelationProvider() { }
-        public PixelationProvider(GlobalCensorOptions globalOpts)
-        {
-            this._globalOpts = globalOpts;
-        }
-
-        public Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level)
-        {
-            var padding = inputImage.GetPadding(_globalOpts);
-            var mutation = CensorEffects.GetMaskedPixelEffect(inputImage, result, padding, level, _globalOpts.ClassStrength.GetValueOrDefault(result.Label, 1F));
-            return Task.FromResult<Action<IImageProcessingContext>?>(mutation);
-            // var cropRect = result.Box.ToRectangle();
-            // var mask = new PathEffectMask(cropRect, result.SourceAngle.GetValueOrDefault(), padding);
-            // var extract = inputImage.Clone(x => {
-            //     x.Crop((Rectangle)mask.GetBounds(inputImage));
-            //     x.Pixelate(GetPixelSize(Math.Max(inputImage.Height, inputImage.Width), level));
-            // });
-            
-            // return Task.FromResult<Action<IImageProcessingContext>?>(mask.GetMutation(extract));
-        }
-
-        
-
-        public bool Supports(string censorType) => censorType.ToLower().StartsWith("pixel");
+        this._globalOpts = globalOpts;
     }
+
+    public Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level)
+    {
+        var padding = inputImage.GetPadding(_globalOpts);
+        var mutation = CensorEffects.GetMaskedPixelEffect(inputImage, result, padding, level, _globalOpts.ClassStrength.GetValueOrDefault(result.Label, 1F));
+        return Task.FromResult<Action<IImageProcessingContext>?>(mutation);
+        // var cropRect = result.Box.ToRectangle();
+        // var mask = new PathEffectMask(cropRect, result.SourceAngle.GetValueOrDefault(), padding);
+        // var extract = inputImage.Clone(x => {
+        //     x.Crop((Rectangle)mask.GetBounds(inputImage));
+        //     x.Pixelate(GetPixelSize(Math.Max(inputImage.Height, inputImage.Width), level));
+        // });
+
+        // return Task.FromResult<Action<IImageProcessingContext>?>(mask.GetMutation(extract));
+    }
+
+
+
+    public bool Supports(string censorType) => censorType.ToLower().StartsWith("pixel");
 }

--- a/src/CensorCore/Censoring/StaticResultsParser.cs
+++ b/src/CensorCore/Censoring/StaticResultsParser.cs
@@ -1,17 +1,19 @@
-namespace CensorCore.Censoring {
+namespace CensorCore.Censoring;
 
-    public class StaticResultsParser : IResultParser {
-        private readonly Dictionary<string, ImageCensorOptions> _options;
-        public ImageCensorOptions? DefaultOptions { get; set; }
+public class StaticResultsParser : IResultParser
+{
+    private readonly Dictionary<string, ImageCensorOptions> _options;
+    public ImageCensorOptions? DefaultOptions { get; set; }
 
-        public StaticResultsParser(Dictionary<string, ImageCensorOptions> options) {
-            this._options = options;
-        }
+    public StaticResultsParser(Dictionary<string, ImageCensorOptions> options)
+    {
+        this._options = options;
+    }
 
-        public ImageCensorOptions? GetOptions(string label, ImageResult? image = null) {
-            return _options.TryGetValue(label, out var opts)
-                ? opts
-                : DefaultOptions ?? new ImageCensorOptions("none");
-        }
+    public ImageCensorOptions? GetOptions(string label, ImageResult? image = null)
+    {
+        return _options.TryGetValue(label, out var opts)
+            ? opts
+            : DefaultOptions ?? new ImageCensorOptions("none");
     }
 }

--- a/src/CensorCore/Censoring/StickerProvider.cs
+++ b/src/CensorCore/Censoring/StickerProvider.cs
@@ -96,7 +96,8 @@ namespace CensorCore.Censoring
                 for (int i = 0; i < resultCount / 1.25 && validImage == null; i++)
                 {
                     var candidate = allFiles.Random(resultCount);
-                    var img = Image.Identify(candidate.RawData, out var format);
+                    var img = Image.Identify(candidate.RawData);
+                    var format = Image.DetectFormat(candidate.RawData);
                     var iRatio = img.Width / img.Height;
                     if (boxRatio == null || CloseEnough(iRatio, boxRatio.Value)) {
                         validImage = new RawImageData(candidate.RawData, format.DefaultMimeType);

--- a/src/CensorCore/Censoring/StickerProvider.cs
+++ b/src/CensorCore/Censoring/StickerProvider.cs
@@ -1,134 +1,151 @@
-using System.Linq;
 using System.Numerics;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 
 
-namespace CensorCore.Censoring
+namespace CensorCore.Censoring;
+
+public static class KnownAssetTypes
 {
-    public static class KnownAssetTypes {
-        public static string Stickers => "stickers";
-    }
-    public class StickerProvider : ICensorTypeProvider
+    public static string Stickers => "stickers";
+}
+public class StickerProvider : ICensorTypeProvider
+{
+    private readonly IAssetStore _store;
+    private readonly GlobalCensorOptions _globalOpts = new GlobalCensorOptions();
+
+    public StickerProvider(IAssetStore store)
     {
-        private readonly IAssetStore _store;
-        private readonly GlobalCensorOptions _globalOpts = new GlobalCensorOptions();
-
-        public StickerProvider(IAssetStore store)
-        {
-            this._store = store;
-        }
-        public StickerProvider(IAssetStore store, GlobalCensorOptions options) : this(store)
-        {
-            this._globalOpts = options;
-        }
-        public async Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level)
-        {
-            var mutations = new List<Action<IImageProcessingContext>>();
-            var padding = inputImage.GetPadding(_globalOpts);
-            float boxRatio = (float)result.Box.Width / result.Box.Height;
-            var options = method.GetOptions("sticker");
-            var defaultToBlur = _globalOpts.ForcePixelBackground.HasValue ? !_globalOpts.ForcePixelBackground.Value : true;
-            var useBlur = options.Parameters != null
-                ? options.Parameters.TryGetFirst("useBlur", out var optionObj) ? (bool.TryParse((string)optionObj, out var useBlurOption) && useBlurOption) : defaultToBlur
-                : defaultToBlur;
-            var usePixels = _globalOpts.ForcePixelBackground == true || ( options.Parameters != null
-                ? options.Parameters.TryGetFirst("usePixels", out var pixelOption) ? (bool.TryParse((string)pixelOption, out var usePixelOption) && usePixelOption) : false
-                : false );
-            var sticker = await GetImageAsync(boxRatio, options.Categories);
-            if (useBlur) {
-                var blurMutation = CensorEffects.GetMaskedBlurEffect(inputImage, result, padding, level, minimumLevel: 10);
-                mutations.Add(blurMutation);
-            } else if (usePixels) {
-                var pixelMutation = CensorEffects.GetMaskedPixelEffect(inputImage, result, padding, level);
-                mutations.Add(pixelMutation);
-            }
-            var effectCenter = result.Box.GetCenter();
-            if (sticker != null) {
-                var stickerImage = Image.Load(sticker);
-                var stickerRatio = stickerImage.Width / stickerImage.Height;
-                if (CloseEnough(stickerRatio, boxRatio)) {
-                    var resizeOpts = new ResizeOptions {
-                        Size = new Size(result.Box.Width, result.Box.Height),
-                        Mode = ResizeMode.Max
-                    };
-                    stickerImage.Mutate(s => {
-                        s.Resize(resizeOpts);
-                    });
-                    if (result.SourceAngle.HasValue) {
-                        var ctr = result.Box.GetCenter();
-                        var affineBuilder = new AffineTransformBuilder();
-                        affineBuilder.PrependTranslation(new Vector2(ctr.X, ctr.Y));
-                        affineBuilder.PrependRotationDegrees(result.SourceAngle.Value);
-                        affineBuilder.AppendTranslation(new Vector2(-ctr.X, -ctr.Y));
-                        stickerImage.Mutate(m => m.Transform(affineBuilder));
-                    }
-                    var targetLoc = new Point(effectCenter.X - (stickerImage.Width/2), effectCenter.Y - (stickerImage.Height/2));
-                    mutations.Add(x => {
-                        x.DrawImage(stickerImage, targetLoc, Math.Min(level/10F,1));
-                    });
-                }
-            }
-            return x => {
-                foreach (var mutation in mutations)
-                {
-                    mutation(x);
-                }
-            };
-        }
-
-        private async Task<byte[]?> GetImageAsync(float? boxRatio, List<string>? categories) {
-            try {
-                var sticker = await this._store.GetRandomImage(KnownAssetTypes.Stickers, boxRatio, categories);
-                return sticker?.RawData;
-            } catch (NotImplementedException) {
-                //ignored
-                //not all providers will implement this, and that's okay
-            }
-            try {
-                var allFiles = await this._store.GetImages(KnownAssetTypes.Stickers, categories);
-                RawImageData? validImage = null;
-                var resultCount = allFiles.Count();
-                //if we pull _80%_ of the total elements by random and they don't match, we're probably not going to find one.
-                for (int i = 0; i < resultCount / 1.25 && validImage == null; i++)
-                {
-                    var candidate = allFiles.Random(resultCount);
-                    var img = Image.Identify(candidate.RawData);
-                    var format = Image.DetectFormat(candidate.RawData);
-                    var iRatio = img.Width / img.Height;
-                    if (boxRatio == null || CloseEnough(iRatio, boxRatio.Value)) {
-                        validImage = new RawImageData(candidate.RawData, format.DefaultMimeType);
-                    }
-                }
-                return validImage?.RawData;
-            } catch {
-                return null;
-            }
-
-        }
-
-        public (bool UseBlur, bool UsePixels) UseBlur((List<string>? Categories, Flurl.QueryParamCollection? Parameters) options) {
-            var defaultToBlur = _globalOpts.ForcePixelBackground.HasValue ? !_globalOpts.ForcePixelBackground.Value : true;
-            var useBlur = options.Parameters != null
-                ? options.Parameters.TryGetFirst("useBlur", out var optionObj) ? (bool.TryParse((string)optionObj, out var useBlurOption) && useBlurOption) : defaultToBlur
-                : defaultToBlur;
-            var usePixels = _globalOpts.ForcePixelBackground == true || ( options.Parameters != null
-                ? options.Parameters.TryGetFirst("usePixels", out var pixelOption) ? (bool.TryParse((string)pixelOption, out var usePixelOption) && usePixelOption) : false
-                : false );
-            return (useBlur, usePixels);
-        }
-
-        
-        private bool CloseEnough(float stickerRatio, float targetRatio)
-        {
-            var diff = stickerRatio / targetRatio;
-            return 0.75 <= diff && diff <= 1.25;
-        }
-
-        public bool Supports(string censorType) => censorType.StartsWith("sticker");
-        public int Layer => 6;
+        this._store = store;
     }
+    public StickerProvider(IAssetStore store, GlobalCensorOptions options) : this(store)
+    {
+        this._globalOpts = options;
+    }
+    public async Task<Action<IImageProcessingContext>?> CensorImage(Image<Rgba32> inputImage, Classification result, string method, int level)
+    {
+        var mutations = new List<Action<IImageProcessingContext>>();
+        var padding = inputImage.GetPadding(_globalOpts);
+        float boxRatio = (float)result.Box.Width / result.Box.Height;
+        var options = method.GetOptions("sticker");
+        var defaultToBlur = _globalOpts.ForcePixelBackground.HasValue ? !_globalOpts.ForcePixelBackground.Value : true;
+        var useBlur = options.Parameters != null
+            ? options.Parameters.TryGetFirst("useBlur", out var optionObj) ? (bool.TryParse((string)optionObj, out var useBlurOption) && useBlurOption) : defaultToBlur
+            : defaultToBlur;
+        var usePixels = _globalOpts.ForcePixelBackground == true || (options.Parameters != null
+            ? options.Parameters.TryGetFirst("usePixels", out var pixelOption) ? (bool.TryParse((string)pixelOption, out var usePixelOption) && usePixelOption) : false
+            : false);
+        var sticker = await GetImageAsync(boxRatio, options.Categories);
+        if (useBlur)
+        {
+            var blurMutation = CensorEffects.GetMaskedBlurEffect(inputImage, result, padding, level, minimumLevel: 10);
+            mutations.Add(blurMutation);
+        }
+        else if (usePixels)
+        {
+            var pixelMutation = CensorEffects.GetMaskedPixelEffect(inputImage, result, padding, level);
+            mutations.Add(pixelMutation);
+        }
+        var effectCenter = result.Box.GetCenter();
+        if (sticker != null)
+        {
+            var stickerImage = Image.Load(sticker);
+            var stickerRatio = stickerImage.Width / stickerImage.Height;
+            if (CloseEnough(stickerRatio, boxRatio))
+            {
+                var resizeOpts = new ResizeOptions
+                {
+                    Size = new Size(result.Box.Width, result.Box.Height),
+                    Mode = ResizeMode.Max
+                };
+                stickerImage.Mutate(s =>
+                {
+                    s.Resize(resizeOpts);
+                });
+                if (result.SourceAngle.HasValue)
+                {
+                    var ctr = result.Box.GetCenter();
+                    var affineBuilder = new AffineTransformBuilder();
+                    affineBuilder.PrependTranslation(new Vector2(ctr.X, ctr.Y));
+                    affineBuilder.PrependRotationDegrees(result.SourceAngle.Value);
+                    affineBuilder.AppendTranslation(new Vector2(-ctr.X, -ctr.Y));
+                    stickerImage.Mutate(m => m.Transform(affineBuilder));
+                }
+                var targetLoc = new Point(effectCenter.X - (stickerImage.Width / 2), effectCenter.Y - (stickerImage.Height / 2));
+                mutations.Add(x =>
+                {
+                    x.DrawImage(stickerImage, targetLoc, Math.Min(level / 10F, 1));
+                });
+            }
+        }
+        return x =>
+        {
+            foreach (var mutation in mutations)
+            {
+                mutation(x);
+            }
+        };
+    }
+
+    private async Task<byte[]?> GetImageAsync(float? boxRatio, List<string>? categories)
+    {
+        try
+        {
+            var sticker = await this._store.GetRandomImage(KnownAssetTypes.Stickers, boxRatio, categories);
+            return sticker?.RawData;
+        }
+        catch (NotImplementedException)
+        {
+            //ignored
+            //not all providers will implement this, and that's okay
+        }
+        try
+        {
+            var allFiles = await this._store.GetImages(KnownAssetTypes.Stickers, categories);
+            RawImageData? validImage = null;
+            var resultCount = allFiles.Count();
+            //if we pull _80%_ of the total elements by random and they don't match, we're probably not going to find one.
+            for (int i = 0; i < resultCount / 1.25 && validImage == null; i++)
+            {
+                var candidate = allFiles.Random(resultCount);
+                var img = Image.Identify(candidate.RawData);
+                var format = Image.DetectFormat(candidate.RawData);
+                var iRatio = img.Width / img.Height;
+                if (boxRatio == null || CloseEnough(iRatio, boxRatio.Value))
+                {
+                    validImage = new RawImageData(candidate.RawData, format.DefaultMimeType);
+                }
+            }
+            return validImage?.RawData;
+        }
+        catch
+        {
+            return null;
+        }
+
+    }
+
+    public (bool UseBlur, bool UsePixels) UseBlur((List<string>? Categories, Flurl.QueryParamCollection? Parameters) options)
+    {
+        var defaultToBlur = _globalOpts.ForcePixelBackground.HasValue ? !_globalOpts.ForcePixelBackground.Value : true;
+        var useBlur = options.Parameters != null
+            ? options.Parameters.TryGetFirst("useBlur", out var optionObj) ? (bool.TryParse((string)optionObj, out var useBlurOption) && useBlurOption) : defaultToBlur
+            : defaultToBlur;
+        var usePixels = _globalOpts.ForcePixelBackground == true || (options.Parameters != null
+            ? options.Parameters.TryGetFirst("usePixels", out var pixelOption) ? (bool.TryParse((string)pixelOption, out var usePixelOption) && usePixelOption) : false
+            : false);
+        return (useBlur, usePixels);
+    }
+
+
+    private bool CloseEnough(float stickerRatio, float targetRatio)
+    {
+        var diff = stickerRatio / targetRatio;
+        return 0.75 <= diff && diff <= 1.25;
+    }
+
+    public bool Supports(string censorType) => censorType.StartsWith("sticker");
+    public int Layer => 6;
 }

--- a/src/CensorCore/CoreExtensions.cs
+++ b/src/CensorCore/CoreExtensions.cs
@@ -1,154 +1,187 @@
-namespace CensorCore {
-    internal static class CoreExtensions {
-        internal static Random Rand = new Random();
-        internal static float GetScoreForClass(this MatchOptions opts, string className)
-        {
-            return opts.ClassScores.GetValueOrDefault(className, opts.MinimumScore);
-        }
+namespace CensorCore;
 
-        internal static BoundingBox ToBox(this float[] coords, float scaleFactor)
-        {
-            return new BoundingBox(coords[0] * scaleFactor, coords[1] * scaleFactor, coords[2] * scaleFactor, coords[3] * scaleFactor);
-        }
-
-        internal static float GetNearest(this IEnumerable<float> values, float target)
-        {
-            var nearest = values.Aggregate((current, next) => Math.Abs((float)current - target) < Math.Abs((float)next - target) ? current : next);
-            return nearest;
-        }
-
-        public static T Random<T>(this IEnumerable<T> input, int? count = null)
-        {
-            return input.ElementAt(Rand.Next(count ?? input.Count()));
-        }
-
-        internal static BoundingBox ScaleBy(this BoundingBox box, float amountX, float amountY)
-        {
-            box.X = box.X - amountX;
-            box.Y = box.Y - amountY;
-            box.Height = Convert.ToInt32(box.Height + (2 * amountY));
-            box.Width = Convert.ToInt32(box.Width + (2 * amountX));
-            return box;
-        }
-
-        internal static int GetSize(this Classification result) {
-            return result.Box.Height*result.Box.Width;
-        }
-
-        internal static bool ContainsAny(this string src, params string[] options) {
-            foreach (var opt in options)
-            {
-                if (src.Contains(opt)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        internal static bool ContainsAny(this string src, StringComparison comparison, params string[] options) {
-            foreach (var opt in options)
-            {
-                if (src.Contains(opt, comparison)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        internal static float GetScaleFactor(this int? value, float defaultValue) {
-            var factor = ((value ?? defaultValue) / defaultValue);
-            return factor;
-        }
-
-        internal static float GetScaleFactor(this int value, float defaultValue) {
-            var factor = (value / defaultValue);
-            return factor;
-        }
-
-        internal static float GetScaleFactor(this float value, float defaultValue) {
-            var factor = (value / defaultValue);
-            return factor;
-        }
-
-        internal static (List<string>? Categories, Flurl.QueryParamCollection? Parameters) GetOptions(this string method, string methodName) {
-            List<string>? categories = null;
-            if (method.Contains('?') && method.Replace(methodName, string.Empty, StringComparison.CurrentCultureIgnoreCase)[0] == '?') {
-                //query string parse
-                var url = new Flurl.Url(method);
-                if (url.QueryParams.GetAll("category") is var cats && cats.Any()) {
-                    categories ??= new List<string>();
-                    categories.AddRange(cats.Cast<string>());
-                }
-                if (url.QueryParams.TryGetFirst("categories", out var catsObj)) {
-                    var splitCats = ((string)catsObj).Split(',', ';').ToList();
-                    if (splitCats.Any()) {
-                        categories ??= new List<string>();
-                        categories.AddRange(splitCats);
-                    }
-                }
-                return (categories, url.QueryParams);
-
-            } else {
-                var catString = method.Split(":").LastOrDefault();
-                if (!string.IsNullOrWhiteSpace(catString)) {
-                    var cats = catString.Split(',', ';').ToList();
-                    if (!cats.Any()) {
-                        throw new InvalidOperationException();
-                    }
-                    else {
-                        categories = cats;
-                    }
-                }
-                return (categories, null);
-            }
-        }
-
-        internal static (List<string>? Categories, bool PreferBox, bool WrapText) GetCaptionOptions(this string method, string methodName) {
-            List<string>? categories = null;
-            var preferBox = false;
-            var wordWrap = true;
-            if (method.Contains('?') && method.Replace(methodName, string.Empty, StringComparison.CurrentCultureIgnoreCase)[0] == '?') {
-                //query string parse
-                var url = new Flurl.Url(method);
-                if (url.QueryParams.GetAll("category") is var cats && cats.Any()) {
-                    categories ??= new List<string>();
-                    categories.AddRange(cats.Cast<string>());
-                }
-                if (url.QueryParams.TryGetFirst("categories", out var catsObj)) {
-                    var splitCats = ((string)catsObj).Split(',', ';').ToList();
-                    if (splitCats.Any()) {
-                        categories ??= new List<string>();
-                        categories.AddRange(splitCats);
-                    }
-                }
-                if (url.QueryParams.TryGetFirst("preferBox", out var preferBoxParam)) {
-                    if (bool.TryParse((string)preferBoxParam, out var boxPreferred)) {
-                        preferBox = boxPreferred;
-                    }
-                }
-                if (url.QueryParams.TryGetFirst("wordWrap", out var wrapObj) && bool.TryParse((string)wrapObj, out var wrap)) {
-                    wordWrap = wrap;
-                }
-                return (categories, preferBox, wordWrap);
-
-            } else {
-                var catString = method.Split(":").Skip(1).LastOrDefault();
-                if (!string.IsNullOrWhiteSpace(catString)) {
-                    var cats = catString.Split(',', ';').ToList();
-                    if (!cats.Any()) {
-                        throw new InvalidOperationException();
-                    }
-                    else {
-                        categories = cats;
-                    }
-                }
-                return (categories, preferBox, wordWrap);
-            }
-        }
-
-        internal static float ClosestTo(this IEnumerable<float> values, float constant) {
-            return values.Aggregate((x,y) => Math.Abs(x-constant) < Math.Abs(y-constant) ? x : y);
-        }
-
+internal static class CoreExtensions
+{
+    internal static Random Rand = new Random();
+    internal static float GetScoreForClass(this MatchOptions opts, string className)
+    {
+        return opts.ClassScores.GetValueOrDefault(className, opts.MinimumScore);
     }
+
+    internal static BoundingBox ToBox(this float[] coords, float scaleFactor)
+    {
+        return new BoundingBox(coords[0] * scaleFactor, coords[1] * scaleFactor, coords[2] * scaleFactor, coords[3] * scaleFactor);
+    }
+
+    internal static float GetNearest(this IEnumerable<float> values, float target)
+    {
+        var nearest = values.Aggregate((current, next) => Math.Abs((float)current - target) < Math.Abs((float)next - target) ? current : next);
+        return nearest;
+    }
+
+    public static T Random<T>(this IEnumerable<T> input, int? count = null)
+    {
+        return input.ElementAt(Rand.Next(count ?? input.Count()));
+    }
+
+    internal static BoundingBox ScaleBy(this BoundingBox box, float amountX, float amountY)
+    {
+        box.X = box.X - amountX;
+        box.Y = box.Y - amountY;
+        box.Height = Convert.ToInt32(box.Height + (2 * amountY));
+        box.Width = Convert.ToInt32(box.Width + (2 * amountX));
+        return box;
+    }
+
+    internal static int GetSize(this Classification result)
+    {
+        return result.Box.Height * result.Box.Width;
+    }
+
+    internal static bool ContainsAny(this string src, params string[] options)
+    {
+        foreach (var opt in options)
+        {
+            if (src.Contains(opt))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    internal static bool ContainsAny(this string src, StringComparison comparison, params string[] options)
+    {
+        foreach (var opt in options)
+        {
+            if (src.Contains(opt, comparison))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    internal static float GetScaleFactor(this int? value, float defaultValue)
+    {
+        var factor = ((value ?? defaultValue) / defaultValue);
+        return factor;
+    }
+
+    internal static float GetScaleFactor(this int value, float defaultValue)
+    {
+        var factor = (value / defaultValue);
+        return factor;
+    }
+
+    internal static float GetScaleFactor(this float value, float defaultValue)
+    {
+        var factor = (value / defaultValue);
+        return factor;
+    }
+
+    internal static (List<string>? Categories, Flurl.QueryParamCollection? Parameters) GetOptions(this string method, string methodName)
+    {
+        List<string>? categories = null;
+        if (method.Contains('?') && method.Replace(methodName, string.Empty, StringComparison.CurrentCultureIgnoreCase)[0] == '?')
+        {
+            //query string parse
+            var url = new Flurl.Url(method);
+            if (url.QueryParams.GetAll("category") is var cats && cats.Any())
+            {
+                categories ??= new List<string>();
+                categories.AddRange(cats.Cast<string>());
+            }
+            if (url.QueryParams.TryGetFirst("categories", out var catsObj))
+            {
+                var splitCats = ((string)catsObj).Split(',', ';').ToList();
+                if (splitCats.Any())
+                {
+                    categories ??= new List<string>();
+                    categories.AddRange(splitCats);
+                }
+            }
+            return (categories, url.QueryParams);
+
+        }
+        else
+        {
+            var catString = method.Split(":").LastOrDefault();
+            if (!string.IsNullOrWhiteSpace(catString))
+            {
+                var cats = catString.Split(',', ';').ToList();
+                if (!cats.Any())
+                {
+                    throw new InvalidOperationException();
+                }
+                else
+                {
+                    categories = cats;
+                }
+            }
+            return (categories, null);
+        }
+    }
+
+    internal static (List<string>? Categories, bool PreferBox, bool WrapText) GetCaptionOptions(this string method, string methodName)
+    {
+        List<string>? categories = null;
+        var preferBox = false;
+        var wordWrap = true;
+        if (method.Contains('?') && method.Replace(methodName, string.Empty, StringComparison.CurrentCultureIgnoreCase)[0] == '?')
+        {
+            //query string parse
+            var url = new Flurl.Url(method);
+            if (url.QueryParams.GetAll("category") is var cats && cats.Any())
+            {
+                categories ??= new List<string>();
+                categories.AddRange(cats.Cast<string>());
+            }
+            if (url.QueryParams.TryGetFirst("categories", out var catsObj))
+            {
+                var splitCats = ((string)catsObj).Split(',', ';').ToList();
+                if (splitCats.Any())
+                {
+                    categories ??= new List<string>();
+                    categories.AddRange(splitCats);
+                }
+            }
+            if (url.QueryParams.TryGetFirst("preferBox", out var preferBoxParam))
+            {
+                if (bool.TryParse((string)preferBoxParam, out var boxPreferred))
+                {
+                    preferBox = boxPreferred;
+                }
+            }
+            if (url.QueryParams.TryGetFirst("wordWrap", out var wrapObj) && bool.TryParse((string)wrapObj, out var wrap))
+            {
+                wordWrap = wrap;
+            }
+            return (categories, preferBox, wordWrap);
+
+        }
+        else
+        {
+            var catString = method.Split(":").Skip(1).LastOrDefault();
+            if (!string.IsNullOrWhiteSpace(catString))
+            {
+                var cats = catString.Split(',', ';').ToList();
+                if (!cats.Any())
+                {
+                    throw new InvalidOperationException();
+                }
+                else
+                {
+                    categories = cats;
+                }
+            }
+            return (categories, preferBox, wordWrap);
+        }
+    }
+
+    internal static float ClosestTo(this IEnumerable<float> values, float constant)
+    {
+        return values.Aggregate((x, y) => Math.Abs(x - constant) < Math.Abs(y - constant) ? x : y);
+    }
+
 }

--- a/src/CensorCore/EmbeddedFontProvider.cs
+++ b/src/CensorCore/EmbeddedFontProvider.cs
@@ -1,41 +1,49 @@
 using System.Reflection;
 using SixLabors.Fonts;
 
-namespace CensorCore {
-    public class EmbeddedFontProvider {
-        private readonly FontCollection _collection;
+namespace CensorCore;
 
-        public EmbeddedFontProvider() {
-            _collection = new FontCollection();
-        }
+public class EmbeddedFontProvider
+{
+    private readonly FontCollection _collection;
 
-        public EmbeddedFontProvider LoadEmbeddedFonts(Assembly? assembly = null) {
-            assembly ??= typeof(EmbeddedFontProvider).Assembly;
-            var model = assembly.GetManifestResourceNames();
-            //TODO: this doesn't match right
-            if (model != null && model.Any()) {
-                var fonts = model.Where(f => Path.GetExtension(f) == ".ttf").ToList();
-                foreach (var font in fonts) {
-                    using var resourceStream = assembly.GetManifestResourceStream(font);
-                    if (resourceStream != null) {
-                        _collection.Add(resourceStream, out var description);
-                    }
+    public EmbeddedFontProvider()
+    {
+        _collection = new FontCollection();
+    }
+
+    public EmbeddedFontProvider LoadEmbeddedFonts(Assembly? assembly = null)
+    {
+        assembly ??= typeof(EmbeddedFontProvider).Assembly;
+        var model = assembly.GetManifestResourceNames();
+        //TODO: this doesn't match right
+        if (model != null && model.Any())
+        {
+            var fonts = model.Where(f => Path.GetExtension(f) == ".ttf").ToList();
+            foreach (var font in fonts)
+            {
+                using var resourceStream = assembly.GetManifestResourceStream(font);
+                if (resourceStream != null)
+                {
+                    _collection.Add(resourceStream, out var description);
                 }
             }
-            return this;
         }
+        return this;
+    }
 
-        public FontCollection GetCollection() {
-            return _collection;
-        }
+    public FontCollection GetCollection()
+    {
+        return _collection;
+    }
 
-        private static byte[]? ExtractStreamResource(Stream resFilestream) {
-            if (resFilestream == null) return null;
-            byte[] bytes = new byte[resFilestream.Length];
-            // Console.WriteLine($"reading stream of length '{resFilestream.Length}'");
-            var reader = new BinaryReader(resFilestream);
-            var readBytes = reader.ReadBytes(Convert.ToInt32(resFilestream.Length));
-            return bytes;
-        }
+    private static byte[]? ExtractStreamResource(Stream resFilestream)
+    {
+        if (resFilestream == null) return null;
+        byte[] bytes = new byte[resFilestream.Length];
+        // Console.WriteLine($"reading stream of length '{resFilestream.Length}'");
+        var reader = new BinaryReader(resFilestream);
+        var readBytes = reader.ReadBytes(Convert.ToInt32(resFilestream.Length));
+        return bytes;
     }
 }

--- a/src/CensorCore/FaceAIService.cs
+++ b/src/CensorCore/FaceAIService.cs
@@ -1,112 +1,124 @@
-using System.Runtime.InteropServices;
 using Microsoft.ML.OnnxRuntime;
 using SixLabors.ImageSharp;
 
-namespace CensorCore
+namespace CensorCore;
+
+public class FaceAIService : IAIService<Point>
 {
-    public class FaceAIService : IAIService<Point> {
-        private readonly InferenceSession _session;
-        private readonly IImageHandler _imageHandler;
+    private readonly InferenceSession _session;
+    private readonly IImageHandler _imageHandler;
 
-        public bool Verbose { get ;set; } = false;
+    public bool Verbose { get; set; } = false;
 
-        public SessionOptions Options => new SessionOptions() {
-            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+    public SessionOptions Options => new SessionOptions()
+    {
+        GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+    };
+
+    public FaceAIService(InferenceSession session, IImageHandler imageHandler)
+    {
+        this._session = session;
+        this._imageHandler = imageHandler;
+    }
+
+    public async Task<ImageResult<Point>?> RunModel(byte[] data, MatchOptions? options = null)
+    {
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Start();
+        var imageData = await this._imageHandler.LoadImageData(data);
+        timer.Stop();
+        Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
+        var result = await RunModelForImage(imageData, options);
+        if (result != null && result.Session != null)
+        {
+            result.Session.ImageLoadTime = timer.Elapsed;
+        }
+        return result;
+    }
+
+    public async Task<ImageResult<Point>?> RunModel(string url, MatchOptions? options = null)
+    {
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Start();
+        var imageData = await this._imageHandler.LoadImage(url);
+        timer.Stop();
+        Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
+        var result = await RunModelForImage(imageData, options);
+        if (result != null && result.Session != null)
+        {
+            result.Session.ImageLoadTime = timer.Elapsed;
+        }
+        return result;
+    }
+
+    private void Log(string message)
+    {
+        if (Verbose)
+        {
+            Console.WriteLine(message);
+        }
+    }
+
+    private async Task<ImageResult<Point>?> RunModelForImage(ImageData imageData, MatchOptions? options)
+    {
+        var timer = new System.Diagnostics.Stopwatch();
+        timer.Restart();
+        var modelInput = await this._imageHandler.LoadToTensor<float>(imageData, new LandmarksLoadOptions());
+        timer.Stop();
+        var tensorLoadTime = timer.Elapsed;
+        Log($"Loaded tensor data in {timer.Elapsed.TotalSeconds}s");
+        timer.Restart();
+        var feeds = GetFeeds(modelInput).ToList();
+        var output = this._session.Run(feeds);
+        var runTime = timer.Elapsed;
+        Log($"Finished model in {timer.Elapsed.TotalSeconds}s");
+        timer.Restart();
+        var classifications = this.GetResults(imageData, output.ToList(), MatchOptions.GetDefault()).ToList();
+        var modelName = string.IsNullOrWhiteSpace(this._session.ModelMetadata.Description)
+            ? this._session.ModelMetadata.GraphName
+            : this._session.ModelMetadata.Description;
+        var sessionMeta = new SessionMetadata(modelName, runTime)
+        {
+            TensorLoadTime = tensorLoadTime
+        };
+        var result = new ImageResult<Point>(imageData, classifications)
+        {
+            Session = sessionMeta
         };
 
-        public FaceAIService(InferenceSession session, IImageHandler imageHandler) {
-            this._session = session;
-            this._imageHandler = imageHandler;
+        Log($"Built results in {timer.Elapsed.TotalSeconds}s");
+        timer.Reset();
+        return result;
+    }
+
+    private IEnumerable<Point> GetResults(ImageData imgData, List<DisposableNamedOnnxValue> tensorOutput, MatchOptions matchOptions)
+    {
+        var results = tensorOutput.ToArray();
+        var length = results.Length;
+        var confidences = results[length - 1].AsTensor<float>().ToArray();
+        var points = new Point[confidences.Length / 2];
+
+        for (int i = 0, j = 0; i < (length = confidences.Length); i += 2)
+        {
+            points[j++] = new Point(
+                (int)(confidences[i + 0] * imgData.SourceImage.Width),
+                (int)(confidences[i + 1] * imgData.SourceImage.Height));
         }
 
-        public async Task<ImageResult<Point>?> RunModel(byte[] data, MatchOptions? options = null) {
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Start();
-            var imageData = await this._imageHandler.LoadImageData(data);
-            timer.Stop();
-            Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
-            var result = await RunModelForImage(imageData, options);
-            if (result != null && result.Session != null) {
-                result.Session.ImageLoadTime = timer.Elapsed;
-            }
-            return result;
+        // dispose
+        foreach (var result in results)
+        {
+            result.Dispose();
         }
 
-        public async Task<ImageResult<Point>?> RunModel(string url, MatchOptions? options = null) {
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Start();
-            var imageData = await this._imageHandler.LoadImage(url);
-            timer.Stop();
-            Log($"Loaded image data in {timer.Elapsed.TotalSeconds}s");
-            var result = await RunModelForImage(imageData, options);
-            if (result != null && result.Session != null) {
-                result.Session.ImageLoadTime = timer.Elapsed;
-            }
-            return result;
-        }
+        var left = points[36];
+        var right = points[45];
 
-        private void Log(string message) {
-            if (Verbose) {
-                Console.WriteLine(message);
-            }
-        }
+        return points;
+    }
 
-        private async Task<ImageResult<Point>?> RunModelForImage(ImageData imageData, MatchOptions? options) {
-            var timer = new System.Diagnostics.Stopwatch();
-            timer.Restart();
-            var modelInput = await this._imageHandler.LoadToTensor<float>(imageData, new LandmarksLoadOptions());
-            timer.Stop();
-            var tensorLoadTime = timer.Elapsed;
-            Log($"Loaded tensor data in {timer.Elapsed.TotalSeconds}s");
-            timer.Restart();
-            var feeds = GetFeeds(modelInput).ToList();
-            var output = this._session.Run(feeds);
-            var runTime = timer.Elapsed;
-            Log($"Finished model in {timer.Elapsed.TotalSeconds}s");
-            timer.Restart();
-            var classifications = this.GetResults(imageData, output.ToList(), MatchOptions.GetDefault()).ToList();
-            var modelName = string.IsNullOrWhiteSpace(this._session.ModelMetadata.Description)
-                ? this._session.ModelMetadata.GraphName
-                : this._session.ModelMetadata.Description;
-            var sessionMeta = new SessionMetadata(modelName, runTime) {
-                TensorLoadTime = tensorLoadTime
-            };
-            var result = new ImageResult<Point>(imageData, classifications) {
-                Session = sessionMeta
-            };
-            
-            Log($"Built results in {timer.Elapsed.TotalSeconds}s");
-            timer.Reset();
-            return result;
-        }
-
-        private IEnumerable<Point> GetResults(ImageData imgData, List<DisposableNamedOnnxValue> tensorOutput, MatchOptions matchOptions) {
-            var results = tensorOutput.ToArray();
-            var length = results.Length;
-			var confidences = results[length - 1].AsTensor<float>().ToArray();
-			var points = new Point[confidences.Length / 2];
-
-			for (int i = 0, j = 0; i < (length = confidences.Length); i += 2)
-			{
-				points[j++] = new Point(
-					(int)(confidences[i + 0] * imgData.SourceImage.Width),
-					(int)(confidences[i + 1] * imgData.SourceImage.Height));
-			}
-
-			// dispose
-			foreach (var result in results)
-			{
-				result.Dispose();
-			}
-
-            var left = points[36];
-            var right = points[45];
-
-            return points;
-        }
-
-        private IEnumerable<NamedOnnxValue> GetFeeds(InputImage<float> input) {
-            return this._session.InputMetadata.Select(im => NamedOnnxValue.CreateFromTensor<float>(im.Key, input.Tensor));
-        }
+    private IEnumerable<NamedOnnxValue> GetFeeds(InputImage<float> input)
+    {
+        return this._session.InputMetadata.Select(im => NamedOnnxValue.CreateFromTensor<float>(im.Key, input.Tensor));
     }
 }

--- a/src/CensorCore/IAssetStore.cs
+++ b/src/CensorCore/IAssetStore.cs
@@ -1,88 +1,93 @@
-using CensorCore.Censoring;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
 
-namespace CensorCore {
+namespace CensorCore;
 
-    public record RawImageData(byte[] RawData, string? MimeType = null) { }
-    public interface IAssetStore {
-        Task<string?> GetRandomCaption(string? category);
-        Task<RawImageData?> GetRandomImage(string imageType, float? ratio, List<string>? category);
-        Task<IEnumerable<RawImageData>> GetImages(string imageType, List<string>? category);
+public record RawImageData(byte[] RawData, string? MimeType = null) { }
+public interface IAssetStore
+{
+    Task<string?> GetRandomCaption(string? category);
+    Task<RawImageData?> GetRandomImage(string imageType, float? ratio, List<string>? category);
+    Task<IEnumerable<RawImageData>> GetImages(string imageType, List<string>? category);
+}
+
+public class EmptyAssetStore : IAssetStore
+{
+    public Task<IEnumerable<RawImageData>> GetImages(string imageType, List<string>? category)
+    {
+        return Task.FromResult(Array.Empty<RawImageData>().AsEnumerable());
     }
 
-    public class EmptyAssetStore : IAssetStore {
-        public Task<IEnumerable<RawImageData>> GetImages(string imageType, List<string>? category) {
-            return Task.FromResult(Array.Empty<RawImageData>().AsEnumerable());
-        }
-
-        public Task<string?> GetRandomCaption(string? category) {
-            return Task.FromResult<string?>(null);
-        }
-
-        public Task<RawImageData?> GetRandomImage(string imageType, float? ratio, List<string>? category) {
-            return Task.FromResult<RawImageData?>(null);
-        }
+    public Task<string?> GetRandomCaption(string? category)
+    {
+        return Task.FromResult<string?>(null);
     }
 
-    public class DebugAssetStore : IAssetStore {
-        private readonly string _imageRoot;
+    public Task<RawImageData?> GetRandomImage(string imageType, float? ratio, List<string>? category)
+    {
+        return Task.FromResult<RawImageData?>(null);
+    }
+}
 
-        public DebugAssetStore()
+public class DebugAssetStore : IAssetStore
+{
+    private readonly string _imageRoot;
+
+    public DebugAssetStore()
+    {
+        //just use beta safety stickers for debug purposes.
+        this._imageRoot = @"X:\BetaSafety\BetaSafety-0.6.0.2\BetaSafety\browser-extension\images\stickers";
+    }
+
+    public Task<IEnumerable<RawImageData>> GetImages(string imageType, List<string>? category)
+    {
+        var allFiles = Directory.EnumerateFiles(this._imageRoot, "*", SearchOption.AllDirectories).ToList();
+        var allImages = allFiles.Select<string, (string FilePath, ImageInfo Image, IImageFormat Format)>(fi =>
         {
-            //just use beta safety stickers for debug purposes.
-            this._imageRoot = @"X:\BetaSafety\BetaSafety-0.6.0.2\BetaSafety\browser-extension\images\stickers";
-        }
+            var info = Image.Identify(fi);
+            var format = Image.DetectFormat(fi);
+            return (FilePath: fi, Image: info, Format: format);
+        });
+        var ratioImages = allImages.Where(i =>
+        {
+            return true;
+        });
+        return Task.FromResult(ratioImages.Select(i => new RawImageData(File.ReadAllBytes(i.FilePath), i.Format.DefaultMimeType)));
+    }
 
-        public Task<IEnumerable<RawImageData>> GetImages(string imageType, List<string>? category) {
-            var allFiles = Directory.EnumerateFiles(this._imageRoot, "*", SearchOption.AllDirectories).ToList();
-            var allImages = allFiles.Select<string, (string FilePath, ImageInfo Image, IImageFormat Format)>(fi =>
+    public async Task<string?> GetRandomCaption(string? category)
+    {
+        var lines = await File.ReadAllLinesAsync(@"X:\BetaSafety\BetaSafety-0.6.0.2\BetaSafety\browser-extension\eyebarCaptions.txt");
+        return lines.Random();
+    }
+
+    public async Task<RawImageData?> GetRandomImage(string imageType, float? ratio, List<string>? category)
+    {
+        var allFiles = Directory.EnumerateFiles(this._imageRoot, "*", SearchOption.AllDirectories).ToList();
+        var allImages =
+            allFiles.Select<string, (string FilePath, ImageInfo Image, IImageFormat Format)>(fi =>
             {
                 var info = Image.Identify(fi);
                 var format = Image.DetectFormat(fi);
                 return (FilePath: fi, Image: info, Format: format);
             });
-            var ratioImages = allImages.Where(i =>
-            {
-                return true;
-            });
-            return Task.FromResult(ratioImages.Select(i => new RawImageData(File.ReadAllBytes(i.FilePath), i.Format.DefaultMimeType)));
-        }
-
-        public async Task<string?> GetRandomCaption(string? category)
+        var ratioImages = allImages.Where(i =>
         {
-            var lines = await File.ReadAllLinesAsync(@"X:\BetaSafety\BetaSafety-0.6.0.2\BetaSafety\browser-extension\eyebarCaptions.txt");
-            return lines.Random();
-        }
-
-        public async Task<RawImageData?> GetRandomImage(string imageType, float? ratio, List<string>? category)
+            var iRatio = i.Image.Width / i.Image.Height;
+            return ratio == null ? true : CloseEnough(iRatio, ratio.Value);
+        });
+        if (ratioImages.Any())
         {
-            var allFiles = Directory.EnumerateFiles(this._imageRoot, "*", SearchOption.AllDirectories).ToList();
-            var allImages =
-                allFiles.Select<string, (string FilePath, ImageInfo Image, IImageFormat Format)>(fi => 
-                {
-                    var info = Image.Identify(fi);
-                    var format = Image.DetectFormat(fi);
-                    return (FilePath: fi, Image: info, Format: format);
-                });
-            var ratioImages = allImages.Where(i =>
-            {
-                var iRatio = i.Image.Width / i.Image.Height;
-                return ratio == null ? true : CloseEnough(iRatio, ratio.Value);
-            });
-            if (ratioImages.Any())
-            {
-                var selected = ratioImages.Random();
-                var bytes = await File.ReadAllBytesAsync(selected.FilePath);
-                return new RawImageData(bytes, selected.Format.DefaultMimeType);
-            }
-            return null;
+            var selected = ratioImages.Random();
+            var bytes = await File.ReadAllBytesAsync(selected.FilePath);
+            return new RawImageData(bytes, selected.Format.DefaultMimeType);
         }
+        return null;
+    }
 
-        private bool CloseEnough(float stickerRatio, float targetRatio)
-        {
-            var diff = stickerRatio / targetRatio;
-            return 0.75 <= diff && diff <= 1.25;
-        }
+    private bool CloseEnough(float stickerRatio, float targetRatio)
+    {
+        var diff = stickerRatio / targetRatio;
+        return 0.75 <= diff && diff <= 1.25;
     }
 }

--- a/src/CensorCore/IAssetStore.cs
+++ b/src/CensorCore/IAssetStore.cs
@@ -36,7 +36,12 @@ namespace CensorCore {
 
         public Task<IEnumerable<RawImageData>> GetImages(string imageType, List<string>? category) {
             var allFiles = Directory.EnumerateFiles(this._imageRoot, "*", SearchOption.AllDirectories).ToList();
-            var allImages = allFiles.Select<string, (string FilePath, IImageInfo Image, IImageFormat Format)>(fi => (FilePath: fi, Image: Image.Identify(fi, out var format), Format: format));
+            var allImages = allFiles.Select<string, (string FilePath, ImageInfo Image, IImageFormat Format)>(fi =>
+            {
+                var info = Image.Identify(fi);
+                var format = Image.DetectFormat(fi);
+                return (FilePath: fi, Image: info, Format: format);
+            });
             var ratioImages = allImages.Where(i =>
             {
                 return true;
@@ -53,7 +58,13 @@ namespace CensorCore {
         public async Task<RawImageData?> GetRandomImage(string imageType, float? ratio, List<string>? category)
         {
             var allFiles = Directory.EnumerateFiles(this._imageRoot, "*", SearchOption.AllDirectories).ToList();
-            var allImages = allFiles.Select<string, (string FilePath, IImageInfo Image, IImageFormat Format)>(fi => (FilePath: fi, Image: Image.Identify(fi, out var format), Format: format));
+            var allImages =
+                allFiles.Select<string, (string FilePath, ImageInfo Image, IImageFormat Format)>(fi => 
+                {
+                    var info = Image.Identify(fi);
+                    var format = Image.DetectFormat(fi);
+                    return (FilePath: fi, Image: info, Format: format);
+                });
             var ratioImages = allImages.Where(i =>
             {
                 var iRatio = i.Image.Width / i.Image.Height;

--- a/src/CensorCore/IImageHandler.cs
+++ b/src/CensorCore/IImageHandler.cs
@@ -1,14 +1,14 @@
-﻿namespace CensorCore {
+﻿namespace CensorCore;
 
-    /// <summary>
-    /// Service type responsible for loading and manipulating images.
-    /// </summary>
-    /// <remarks>
-    /// This type is primarily to keep concerns clean, but may be altered in future to remove the hard dependency on ImageSharp
-    /// </remarks>
-    public interface IImageHandler {
-        Task<ImageData> LoadImage(string path);
-        Task<ImageData> LoadImageData(byte[] data);
-        Task<InputImage<T>> LoadToTensor<T>(ImageData image, TensorLoadOptions<T> options);
-    }
+/// <summary>
+/// Service type responsible for loading and manipulating images.
+/// </summary>
+/// <remarks>
+/// This type is primarily to keep concerns clean, but may be altered in future to remove the hard dependency on ImageSharp
+/// </remarks>
+public interface IImageHandler
+{
+    Task<ImageData> LoadImage(string path);
+    Task<ImageData> LoadImageData(byte[] data);
+    Task<InputImage<T>> LoadToTensor<T>(ImageData image, TensorLoadOptions<T> options);
 }

--- a/src/CensorCore/ImageData.cs
+++ b/src/CensorCore/ImageData.cs
@@ -2,17 +2,17 @@
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 
-namespace CensorCore
+namespace CensorCore;
+
+public class ImageData
 {
-    public class ImageData {
-        public ImageData(Image<Rgba32> srcImage)
-        {
-            SourceImage = srcImage;
-        }
-        public Image<Rgba32> SourceImage { get; internal set; }
-        internal Image<Rgba32>? SampledImage {get;set;}
-        internal IImageFormat? Format {get;set;}
-        public SizeF ScaleFactor {get;set;} = new SizeF(1,1);
-        internal Point SampleOffset {get;set;} = new Point(0,0);
+    public ImageData(Image<Rgba32> srcImage)
+    {
+        SourceImage = srcImage;
     }
+    public Image<Rgba32> SourceImage { get; internal set; }
+    internal Image<Rgba32>? SampledImage { get; set; }
+    internal IImageFormat? Format { get; set; }
+    public SizeF ScaleFactor { get; set; } = new SizeF(1, 1);
+    internal Point SampleOffset { get; set; } = new Point(0, 0);
 }

--- a/src/CensorCore/ImageResult.cs
+++ b/src/CensorCore/ImageResult.cs
@@ -1,62 +1,63 @@
 using System.Text.Json.Serialization;
 
-namespace CensorCore
+namespace CensorCore;
+
+/// <summary>
+/// The final result of classifying an image with the model.
+/// </summary>
+public class ImageResult : ImageResult<Classification>
 {
     /// <summary>
-    /// The final result of classifying an image with the model.
+    /// Creates a new result object with a given image and set of results.
     /// </summary>
-    public class ImageResult : ImageResult<Classification>
+    /// <param name="imgData">The image that was classified.</param>
+    /// <param name="results">Any classification results for the given image.</param>
+    public ImageResult(ImageData imgData, List<Classification> results) : base(imgData, results)
     {
-        /// <summary>
-        /// Creates a new result object with a given image and set of results.
-        /// </summary>
-        /// <param name="imgData">The image that was classified.</param>
-        /// <param name="results">Any classification results for the given image.</param>
-        public ImageResult(ImageData imgData, List<Classification> results) : base(imgData, results)
-        {
-        }
+    }
+}
+
+/// <summary>
+/// The final result of classifying an image with the model.
+/// </summary>
+public class ImageResult<T>
+{
+    /// <summary>
+    /// Creates a new result object with a given image and set of results.
+    /// </summary>
+    /// <param name="imgData">The image that was classified.</param>
+    /// <param name="results">Any classification results for the given image.</param>
+    public ImageResult(ImageData imgData, List<T> results)
+    {
+        this.ImageData = imgData;
+        this.Results = results;
     }
 
     /// <summary>
-    /// The final result of classifying an image with the model.
+    /// The source data for the image the results relate to.
     /// </summary>
-    public class ImageResult<T>
+    [JsonIgnore]
+    public ImageData ImageData { get; protected set; }
+
+    /// <summary>
+    /// A list of all the classification matching results for this image.
+    /// </summary>
+    /// <value>The classification results.</value>
+    public List<T> Results { get; protected set; }
+
+    public SessionMetadata? Session { get; set; }
+}
+
+public class SessionMetadata
+{
+    public TimeSpan ModelRunTime { get; set; }
+    public TimeSpan? ImageLoadTime { get; set; }
+    public TimeSpan? TensorLoadTime { get; set; }
+    public string ModelName { get; set; }
+
+    public SessionMetadata(string modelName, TimeSpan modelRunTime)
     {
-        /// <summary>
-        /// Creates a new result object with a given image and set of results.
-        /// </summary>
-        /// <param name="imgData">The image that was classified.</param>
-        /// <param name="results">Any classification results for the given image.</param>
-        public ImageResult(ImageData imgData, List<T> results)
-        {
-            this.ImageData = imgData;
-            this.Results = results;
-        }
-
-        /// <summary>
-        /// The source data for the image the results relate to.
-        /// </summary>
-        [JsonIgnore]
-        public ImageData ImageData { get; protected set; }
-
-        /// <summary>
-        /// A list of all the classification matching results for this image.
-        /// </summary>
-        /// <value>The classification results.</value>
-        public List<T> Results { get; protected set;}
-
-        public SessionMetadata? Session {get; set;}
-    }
-
-    public class SessionMetadata {
-        public TimeSpan ModelRunTime {get;set;}
-        public TimeSpan? ImageLoadTime {get;set;}
-        public TimeSpan? TensorLoadTime {get;set;}
-        public string ModelName {get;set;}
-
-        public SessionMetadata(string modelName, TimeSpan modelRunTime) {
-            ModelName = modelName;
-            ModelRunTime = modelRunTime;
-        }
+        ModelName = modelName;
+        ModelRunTime = modelRunTime;
     }
 }

--- a/src/CensorCore/ImageSharpExtensions.cs
+++ b/src/CensorCore/ImageSharpExtensions.cs
@@ -1,98 +1,102 @@
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 
-namespace CensorCore
+namespace CensorCore;
+
+internal static class ImageSharpExtensions
 {
-    internal static class ImageSharpExtensions
+    internal static Rectangle ToRectangle(this BoundingBox box)
     {
-        internal static Rectangle ToRectangle(this BoundingBox box)
-        {
-            return new Rectangle(Convert.ToInt32(box.X), Convert.ToInt32(box.Y), box.Width, box.Height);
-        }
-
-        public static Rectangle GetPadded(this Rectangle rect, int padAmount = 1)
-        {
-            return new Rectangle(rect.X - padAmount, rect.Y - padAmount, rect.Width + (2 * padAmount), rect.Height + (2 * padAmount));
-        }
-
-        public static Rectangle GetPadded(this Rectangle rect, int padAmount, Image inputImage)
-        {
-            return new Rectangle(rect.X - padAmount, rect.Y - padAmount, rect.Width + (2 * padAmount), rect.Height + (2 * padAmount)).FitToBounds(inputImage);
-        }
-
-        public static Point ToPoint(this BoundingBox box)
-        {
-            return new Point(Convert.ToInt32(box.X), Convert.ToInt32(box.Y));
-        }
-
-        public static Point GetCenter(this BoundingBox box)
-        {
-            return new Point(Convert.ToInt32(box.X + (box.Width / 2)), Convert.ToInt32(box.Y + (box.Height / 2)));
-        }
-
-        public static Point GetCenter(this Rectangle rect)
-        {
-            return new Point(Convert.ToInt32(rect.X + (rect.Width / 2)), Convert.ToInt32(rect.Y + (rect.Height / 2)));
-        }
-
-        public static PointF GetCenter(this Image i) {
-            return new PointF(i.Width/2, i.Height/2);
-        }
-
-        public static int GetPadding(this Image inputImage, Censoring.GlobalCensorOptions opts) {
-            return Convert.ToInt32(Math.Max(10, Math.Min(inputImage.Width, inputImage.Height)/(40*1/(opts.PaddingScale ?? 1))));
-        }
-
-        public static Rectangle FitToBounds(this Rectangle rect, Image img) {
-            return (Rectangle)((RectangleF)rect).FitToBounds(img);
-        }
-
-        public static RectangleF FitToBounds(this RectangleF rect, Image img) {
-            rect.X = Math.Max(rect.X, 0);
-            rect.Y = Math.Max(rect.Y, 0);
-            if (rect.X+rect.Width > img.Width) {
-                rect.Width = img.Width - rect.X;
-            }
-            if (rect.Y+rect.Height > img.Height) {
-                rect.Height = img.Height - rect.Y;
-            }
-            return rect;
-        }
-
-        public static BoundingBox FitToBounds(this BoundingBox rect, Image img) {
-            return new BoundingBox(
-                Math.Max(rect.X, 0),
-                Math.Max(rect.Y, 0),
-                Math.Min(rect.X+rect.Width, img.Width),
-                Math.Min(rect.Y+rect.Height, img.Height)
-            );
-        }
-
-        public static float GetDistanceTo(this Point a, Point b) {
-            return (float)Math.Sqrt(Math.Pow(a.X - b.X, 2) + Math.Pow(a.Y - b.Y, 2));
-        }
-
-        public static Point GetMidpointBetween(this Point a, Point b) {
-            return new Point((a.X + b.X)/2, (a.Y + b.Y)/2);
-        }
-
-        public static float GetAngleTo(this Point start, Point end) {
-            var deltaY = start.Y - end.Y;
-            var deltaX = end.X - start.X;
-            var angle = (180/Math.PI) * Math.Atan2(deltaY, deltaX);
-            return (float)(-angle);
-        }
-
-        internal static BoundingBox ToBox(this float[] coords, SizeF scaleFactor, Point offset)
-        {
-            var offX = offset.X*scaleFactor.Width;
-            var offY = offset.Y*scaleFactor.Height;
-            // return new BoundingBox((coords[0]+offset.X) * scaleFactor.Width, (coords[1]+offset.Y) * scaleFactor.Height, (coords[2]+offset.X) * scaleFactor.Width, (coords[3]+offset.Y) * scaleFactor.Height);
-            return new BoundingBox((coords[0]*scaleFactor.Width) + offX, (coords[1]*scaleFactor.Height) + offY, (coords[2]*scaleFactor.Width) + offX, (coords[3]*scaleFactor.Height) +offY);
-        }
+        return new Rectangle(Convert.ToInt32(box.X), Convert.ToInt32(box.Y), box.Width, box.Height);
     }
 
+    public static Rectangle GetPadded(this Rectangle rect, int padAmount = 1)
+    {
+        return new Rectangle(rect.X - padAmount, rect.Y - padAmount, rect.Width + (2 * padAmount), rect.Height + (2 * padAmount));
+    }
 
+    public static Rectangle GetPadded(this Rectangle rect, int padAmount, Image inputImage)
+    {
+        return new Rectangle(rect.X - padAmount, rect.Y - padAmount, rect.Width + (2 * padAmount), rect.Height + (2 * padAmount)).FitToBounds(inputImage);
+    }
+
+    public static Point ToPoint(this BoundingBox box)
+    {
+        return new Point(Convert.ToInt32(box.X), Convert.ToInt32(box.Y));
+    }
+
+    public static Point GetCenter(this BoundingBox box)
+    {
+        return new Point(Convert.ToInt32(box.X + (box.Width / 2)), Convert.ToInt32(box.Y + (box.Height / 2)));
+    }
+
+    public static Point GetCenter(this Rectangle rect)
+    {
+        return new Point(Convert.ToInt32(rect.X + (rect.Width / 2)), Convert.ToInt32(rect.Y + (rect.Height / 2)));
+    }
+
+    public static PointF GetCenter(this Image i)
+    {
+        return new PointF(i.Width / 2, i.Height / 2);
+    }
+
+    public static int GetPadding(this Image inputImage, Censoring.GlobalCensorOptions opts)
+    {
+        return Convert.ToInt32(Math.Max(10, Math.Min(inputImage.Width, inputImage.Height) / (40 * 1 / (opts.PaddingScale ?? 1))));
+    }
+
+    public static Rectangle FitToBounds(this Rectangle rect, Image img)
+    {
+        return (Rectangle)((RectangleF)rect).FitToBounds(img);
+    }
+
+    public static RectangleF FitToBounds(this RectangleF rect, Image img)
+    {
+        rect.X = Math.Max(rect.X, 0);
+        rect.Y = Math.Max(rect.Y, 0);
+        if (rect.X + rect.Width > img.Width)
+        {
+            rect.Width = img.Width - rect.X;
+        }
+        if (rect.Y + rect.Height > img.Height)
+        {
+            rect.Height = img.Height - rect.Y;
+        }
+        return rect;
+    }
+
+    public static BoundingBox FitToBounds(this BoundingBox rect, Image img)
+    {
+        return new BoundingBox(
+            Math.Max(rect.X, 0),
+            Math.Max(rect.Y, 0),
+            Math.Min(rect.X + rect.Width, img.Width),
+            Math.Min(rect.Y + rect.Height, img.Height)
+        );
+    }
+
+    public static float GetDistanceTo(this Point a, Point b)
+    {
+        return (float)Math.Sqrt(Math.Pow(a.X - b.X, 2) + Math.Pow(a.Y - b.Y, 2));
+    }
+
+    public static Point GetMidpointBetween(this Point a, Point b)
+    {
+        return new Point((a.X + b.X) / 2, (a.Y + b.Y) / 2);
+    }
+
+    public static float GetAngleTo(this Point start, Point end)
+    {
+        var deltaY = start.Y - end.Y;
+        var deltaX = end.X - start.X;
+        var angle = (180 / Math.PI) * Math.Atan2(deltaY, deltaX);
+        return (float)(-angle);
+    }
+
+    internal static BoundingBox ToBox(this float[] coords, SizeF scaleFactor, Point offset)
+    {
+        var offX = offset.X * scaleFactor.Width;
+        var offY = offset.Y * scaleFactor.Height;
+        // return new BoundingBox((coords[0]+offset.X) * scaleFactor.Width, (coords[1]+offset.Y) * scaleFactor.Height, (coords[2]+offset.X) * scaleFactor.Width, (coords[3]+offset.Y) * scaleFactor.Height);
+        return new BoundingBox((coords[0] * scaleFactor.Width) + offX, (coords[1] * scaleFactor.Height) + offY, (coords[2] * scaleFactor.Width) + offX, (coords[3] * scaleFactor.Height) + offY);
+    }
 }

--- a/src/CensorCore/ImageSharpHandler.cs
+++ b/src/CensorCore/ImageSharpHandler.cs
@@ -1,152 +1,167 @@
-using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
 
-namespace CensorCore
+namespace CensorCore;
+
+public class ImageSharpHandler : IImageHandler
 {
-    public class ImageSharpHandler : IImageHandler
+    private readonly int _maxWidth;
+    private readonly int _maxHeight;
+    public bool ForceFit { get; set; }
+
+    public ImageSharpHandler()
     {
-        private readonly int _maxWidth;
-        private readonly int _maxHeight;
-        public bool ForceFit {get;set;}
+        this._maxHeight = 1080;
+        this._maxWidth = 1920;
+    }
 
-        public ImageSharpHandler()
-        {
-            this._maxHeight = 1080;
-            this._maxWidth = 1920;
-        }
+    public ImageSharpHandler(int? maxWidth, int? maxHeight)
+    {
+        this._maxWidth = maxWidth ?? 1920;
+        this._maxHeight = maxHeight ?? 1080;
+    }
 
-        public ImageSharpHandler(int? maxWidth, int? maxHeight)
-        {
-            this._maxWidth = maxWidth ?? 1920;
-            this._maxHeight = maxHeight ?? 1080;
-        }
+    private async Task<byte[]> DownloadFile(Uri path)
+    {
+        using var client = new HttpClient();
+        var result = await client.GetByteArrayAsync(path.ToString());
+        return result;
+    }
 
-        private async Task<byte[]> DownloadFile(Uri path)
+    public async Task<ImageData> LoadImage(string path)
+    {
+        if (path.StartsWith("data:"))
         {
-            using var client = new HttpClient();
-            var result = await client.GetByteArrayAsync(path.ToString());
-            return result;
-        }
-
-        public async Task<ImageData> LoadImage(string path)
-        {
-            if (path.StartsWith("data:")) {
-                try {
-                    var encodedBytes = path.Split(',')[1];
-                    var contents = Convert.FromBase64String(encodedBytes);
-                    return await LoadImageData(contents);
-                } catch (Exception e) {
-                    throw new Exception("Invalid base64 data URI!", e);
-                }
-            }
-            if (File.Exists(path))
+            try
             {
-                return await LoadImageData(await File.ReadAllBytesAsync(path));
-            }
-            if (Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out var uri))
-            {
-                var contents = uri.IsFile
-                    ? await File.ReadAllBytesAsync(System.Web.HttpUtility.UrlDecode(uri.AbsolutePath))
-                    : await DownloadFile(uri);
+                var encodedBytes = path.Split(',')[1];
+                var contents = Convert.FromBase64String(encodedBytes);
                 return await LoadImageData(contents);
             }
-
-            throw new Exception("Could not parse image URL!");
-        }
-
-        private Image<Rgba32> ResizeImage(Image<Rgba32> image) {
-            var width = image.Width;
-            var height = image.Height;
-            var landscape = width > height;
-            if (!ForceFit) {
-                var sampled = image.Clone(ctx => {
-                    if (landscape && width > this._maxWidth) {
-                        ctx.Resize(this._maxWidth, 0);
-                    } else if (!landscape && height > this._maxHeight) {
-                        ctx.Resize(0, this._maxHeight);
-                    }
-                });
-                return sampled;
-            } else {
-                return image.Clone(ctx => {
-                    ctx.Resize(new ResizeOptions {
-                        Mode = ResizeMode.Max,
-                        Size = new Size(this._maxWidth, this._maxHeight)
-                    });
-                });
+            catch (Exception e)
+            {
+                throw new Exception("Invalid base64 data URI!", e);
             }
         }
-
-        [Obsolete("Use typed variant instead", true)]
-        public Task<InputImage> LoadToTensor(ImageData image)
+        if (File.Exists(path))
         {
-            var img = image.SampledImage ?? image.SourceImage;
-            var origHeight = img.Height;
-            // img.CopyPixelDataTo(new Span<Rgba32>());
-            Tensor<float> data = new DenseTensor<float>(new[] {1, img.Height, img.Width, 3});
-            img.ProcessPixelRows(accessor =>
-            {
-                for (int y = 0; y < accessor.Height; y++)
-                {
-                    var pixelRow = accessor.GetRowSpan(y);
-
-                    for (int x = 0; x < pixelRow.Length; x++)
-                    {
-                        // Get a reference to the pixel at position x
-                        ref Rgba32 pixel = ref pixelRow[x];
-                        data[0, y, x, 0] = pixel.B - 103.939F;
-                        data[0, y, x, 1] = pixel.G - 116.779F;
-                        data[0, y, x, 2] = pixel.R - 123.68F;
-                    }
-                }
-            });
-            return Task.FromResult(new InputImage(data, image));
+            return await LoadImageData(await File.ReadAllBytesAsync(path));
+        }
+        if (Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out var uri))
+        {
+            var contents = uri.IsFile
+                ? await File.ReadAllBytesAsync(System.Web.HttpUtility.UrlDecode(uri.AbsolutePath))
+                : await DownloadFile(uri);
+            return await LoadImageData(contents);
         }
 
-        public Task<InputImage<T>> LoadToTensor<T>(ImageData image, TensorLoadOptions<T> options) {
-            var img = image.SampledImage ?? image.SourceImage;
-            var origHeight = img.Height;
-            // img.CopyPixelDataTo(new Span<Rgba32>());
-            Tensor<T> data = new DenseTensor<T>(options.Dimensions(img));
-            img.ProcessPixelRows(accessor =>
-            {
-                for (int y = 0; y < accessor.Height; y++)
-                {
-                    var pixelRow = accessor.GetRowSpan(y);
+        throw new Exception("Could not parse image URL!");
+    }
 
-                    for (int x = 0; x < pixelRow.Length; x++)
-                    {
-                        // Get a reference to the pixel at position x
-                        ref Rgba32 pixel = ref pixelRow[x];
-                        if (options.LoadPixel != null) {
-                            options.LoadPixel(data, new Point(x, y), ref pixel);
-                        }
-                    }
+    private Image<Rgba32> ResizeImage(Image<Rgba32> image)
+    {
+        var width = image.Width;
+        var height = image.Height;
+        var landscape = width > height;
+        if (!ForceFit)
+        {
+            var sampled = image.Clone(ctx =>
+            {
+                if (landscape && width > this._maxWidth)
+                {
+                    ctx.Resize(this._maxWidth, 0);
+                }
+                else if (!landscape && height > this._maxHeight)
+                {
+                    ctx.Resize(0, this._maxHeight);
                 }
             });
-            return Task.FromResult(new InputImage<T>(data, image));
+            return sampled;
         }
-
-        public Task<ImageData> LoadImageData(byte[] contents) {
-            var img = Image.Load<Rgba32>(contents);
-            var format = Image.DetectFormat(contents);
-            var frameCount = img.Frames.Count;
-            for (int i = 1; i < frameCount; i++)
+        else
+        {
+            return image.Clone(ctx =>
             {
-                img.Frames.RemoveFrame(frameCount - i);
+                ctx.Resize(new ResizeOptions
+                {
+                    Mode = ResizeMode.Max,
+                    Size = new Size(this._maxWidth, this._maxHeight)
+                });
+            });
+        }
+    }
+
+    [Obsolete("Use typed variant instead", true)]
+    public Task<InputImage> LoadToTensor(ImageData image)
+    {
+        var img = image.SampledImage ?? image.SourceImage;
+        var origHeight = img.Height;
+        // img.CopyPixelDataTo(new Span<Rgba32>());
+        Tensor<float> data = new DenseTensor<float>(new[] { 1, img.Height, img.Width, 3 });
+        img.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                var pixelRow = accessor.GetRowSpan(y);
+
+                for (int x = 0; x < pixelRow.Length; x++)
+                {
+                    // Get a reference to the pixel at position x
+                    ref Rgba32 pixel = ref pixelRow[x];
+                    data[0, y, x, 0] = pixel.B - 103.939F;
+                    data[0, y, x, 1] = pixel.G - 116.779F;
+                    data[0, y, x, 2] = pixel.R - 123.68F;
+                }
             }
-            var samples = this.ResizeImage(img);
-            var scaleSize = new SizeF((float)img.Width / samples.Width, (float)img.Height / samples.Height);
-            return Task.FromResult(new ImageData(img) {
-                SampledImage = samples,
-                ScaleFactor = scaleSize,
-                Format = format
-            });
+        });
+        return Task.FromResult(new InputImage(data, image));
+    }
+
+    public Task<InputImage<T>> LoadToTensor<T>(ImageData image, TensorLoadOptions<T> options)
+    {
+        var img = image.SampledImage ?? image.SourceImage;
+        var origHeight = img.Height;
+        // img.CopyPixelDataTo(new Span<Rgba32>());
+        Tensor<T> data = new DenseTensor<T>(options.Dimensions(img));
+        img.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                var pixelRow = accessor.GetRowSpan(y);
+
+                for (int x = 0; x < pixelRow.Length; x++)
+                {
+                    // Get a reference to the pixel at position x
+                    ref Rgba32 pixel = ref pixelRow[x];
+                    if (options.LoadPixel != null)
+                    {
+                        options.LoadPixel(data, new Point(x, y), ref pixel);
+                    }
+                }
+            }
+        });
+        return Task.FromResult(new InputImage<T>(data, image));
+    }
+
+    public Task<ImageData> LoadImageData(byte[] contents)
+    {
+        var img = Image.Load<Rgba32>(contents);
+        var format = Image.DetectFormat(contents);
+        var frameCount = img.Frames.Count;
+        for (int i = 1; i < frameCount; i++)
+        {
+            img.Frames.RemoveFrame(frameCount - i);
         }
+        var samples = this.ResizeImage(img);
+        var scaleSize = new SizeF((float)img.Width / samples.Width, (float)img.Height / samples.Height);
+        return Task.FromResult(new ImageData(img)
+        {
+            SampledImage = samples,
+            ScaleFactor = scaleSize,
+            Format = format
+        });
     }
 }

--- a/src/CensorCore/InputImage.cs
+++ b/src/CensorCore/InputImage.cs
@@ -2,47 +2,46 @@
 
 using Microsoft.ML.OnnxRuntime.Tensors;
 
-namespace CensorCore
+namespace CensorCore;
+
+/// <summary>
+/// A simple utility type for the inputs required for classification.
+/// </summary>
+public class InputImage
 {
     /// <summary>
-    /// A simple utility type for the inputs required for classification.
+    /// The image data correctly formatted as a Tensor for model input.
     /// </summary>
-    public class InputImage
+    /// <value>The image data in Tensor form.</value>
+    /// <remarks>Any pixel/array/value manipulation should have been completed before now</remarks>
+    internal Tensor<float> Tensor { get; set; }
+
+    public InputImage(Tensor<float> tensor, ImageData image)
     {
-        /// <summary>
-        /// The image data correctly formatted as a Tensor for model input.
-        /// </summary>
-        /// <value>The image data in Tensor form.</value>
-        /// <remarks>Any pixel/array/value manipulation should have been completed before now</remarks>
-        internal Tensor<float> Tensor { get; set; }
-
-        public InputImage(Tensor<float> tensor, ImageData image)
-        {
-            Tensor = tensor;
-            Image = image;
-        }
-
-        ImageData Image { get; set; }
+        Tensor = tensor;
+        Image = image;
     }
 
+    ImageData Image { get; set; }
+}
+
+/// <summary>
+/// A simple utility type for the inputs required for classification.
+/// </summary>
+public class InputImage<T>
+{
     /// <summary>
-    /// A simple utility type for the inputs required for classification.
+    /// The image data correctly formatted as a Tensor for model input.
     /// </summary>
-    public class InputImage<T>
+    /// <value>The image data in Tensor form.</value>
+    /// <remarks>Any pixel/array/value manipulation should have been completed before now</remarks>
+    internal Tensor<T> Tensor { get; set; }
+
+    public InputImage(Tensor<T> tensor, ImageData image)
     {
-        /// <summary>
-        /// The image data correctly formatted as a Tensor for model input.
-        /// </summary>
-        /// <value>The image data in Tensor form.</value>
-        /// <remarks>Any pixel/array/value manipulation should have been completed before now</remarks>
-        internal Tensor<T> Tensor { get; set; }
-
-        public InputImage(Tensor<T> tensor, ImageData image)
-        {
-            Tensor = tensor;
-            Image = image;
-        }
-
-        internal ImageData Image { get; set; }
+        Tensor = tensor;
+        Image = image;
     }
+
+    internal ImageData Image { get; set; }
 }

--- a/src/CensorCore/MatchOptions.cs
+++ b/src/CensorCore/MatchOptions.cs
@@ -1,34 +1,36 @@
-namespace CensorCore {
+namespace CensorCore;
+
+/// <summary>
+/// The options used to control what classification results are included in the final output.
+/// </summary>
+public class MatchOptions
+{
     /// <summary>
-    /// The options used to control what classification results are included in the final output.
+    /// The default score required for a classification to be considered a valid match.
     /// </summary>
-    public class MatchOptions
+    /// <value>The minimum required confidence/score.</value>
+    public float MinimumScore { get; set; } = 0.6F;
+
+    /// <summary>
+    /// Class-specific scores for classification results. Class-specific scores are preferred when evaluating matches, 
+    /// falling back to the minimum score if no class-specific one is provided.
+    /// </summary>
+    /// <typeparam name="string">The class name as returned from the model.</typeparam>
+    /// <typeparam name="float">The minimum required confidence/score.</typeparam>
+    /// <returns></returns>
+    public Dictionary<string, float> ClassScores { get; set; } = new Dictionary<string, float>();
+
+    /// <summary>
+    /// Returns a set of sane defaults for matching results.
+    /// </summary>
+    /// <returns>Default match options.</returns>
+    public static MatchOptions GetDefault()
     {
-        /// <summary>
-        /// The default score required for a classification to be considered a valid match.
-        /// </summary>
-        /// <value>The minimum required confidence/score.</value>
-        public float MinimumScore {get;set;} = 0.6F;
-
-        /// <summary>
-        /// Class-specific scores for classification results. Class-specific scores are preferred when evaluating matches, 
-        /// falling back to the minimum score if no class-specific one is provided.
-        /// </summary>
-        /// <typeparam name="string">The class name as returned from the model.</typeparam>
-        /// <typeparam name="float">The minimum required confidence/score.</typeparam>
-        /// <returns></returns>
-        public Dictionary<string, float> ClassScores {get;set;} = new Dictionary<string, float>();
-
-        /// <summary>
-        /// Returns a set of sane defaults for matching results.
-        /// </summary>
-        /// <returns>Default match options.</returns>
-        public static MatchOptions GetDefault() {
-            var complexClasses = AIService.ClassList.Where(cn => cn.Split('_').Length > 2).ToDictionary(c => c, v => v.Contains("COVERED") ? 0.6F : 0.4F);
-            return new MatchOptions() {
-                MinimumScore = 0.55F,
-                ClassScores = complexClasses
-            };
-        }
+        var complexClasses = AIService.ClassList.Where(cn => cn.Split('_').Length > 2).ToDictionary(c => c, v => v.Contains("COVERED") ? 0.6F : 0.4F);
+        return new MatchOptions()
+        {
+            MinimumScore = 0.55F,
+            ClassScores = complexClasses
+        };
     }
 }

--- a/src/CensorCore/TensorLoadOptions.cs
+++ b/src/CensorCore/TensorLoadOptions.cs
@@ -3,106 +3,125 @@ using Microsoft.ML.OnnxRuntime.Tensors;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
-namespace CensorCore {
-    public delegate void ActionRef<T>(Tensor<T> data, Point point, ref Rgba32 pixel);
-    // public delegate void ActionRef<Tensor<T>, Rgba32>(T data, ref Rgba32 item);
-    public abstract class TensorLoadOptions<T> {
-        public Func<Image, int[]> Dimensions { get; }
+namespace CensorCore;
 
-        public TensorLoadOptions(Func<Image, int[]> dimensions) {
-            Dimensions = dimensions;
-        }
+public delegate void ActionRef<T>(Tensor<T> data, Point point, ref Rgba32 pixel);
+// public delegate void ActionRef<Tensor<T>, Rgba32>(T data, ref Rgba32 item);
+public abstract class TensorLoadOptions<T>
+{
+    public Func<Image, int[]> Dimensions { get; }
 
-        public virtual ActionRef<T>? LoadPixel {get;protected set;}
-        
-        public virtual IEnumerable<NamedOnnxValue> GetFeeds(InferenceSession session, InputImage<float> input) {
-            return session.InputMetadata.Select(im => NamedOnnxValue.CreateFromTensor<float>(im.Key, input.Tensor));
-        }
+    public TensorLoadOptions(Func<Image, int[]> dimensions)
+    {
+        Dimensions = dimensions;
     }
 
-    public class NudeNetLoadOptions : TensorLoadOptions<float> {
-        public NudeNetLoadOptions() : base(img => new[] {1, img.Height, img.Width, 3}) {
-            LoadPixel = LoadNudeNetPixels;
-        }
+    public virtual ActionRef<T>? LoadPixel { get; protected set; }
 
-        private void LoadNudeNetPixels(Tensor<float> data, Point point, ref Rgba32 pixel) {
-            var y = point.Y;
-            var x = point.X;
-            data[0, y, x, 0] = pixel.B - 103.939F;
-            data[0, y, x, 1] = pixel.G - 116.779F;
-            data[0, y, x, 2] = pixel.R - 123.68F;
-        }
+    public virtual IEnumerable<NamedOnnxValue> GetFeeds(InferenceSession session, InputImage<float> input)
+    {
+        return session.InputMetadata.Select(im => NamedOnnxValue.CreateFromTensor<float>(im.Key, input.Tensor));
+    }
+}
+
+public class NudeNetLoadOptions : TensorLoadOptions<float>
+{
+    public NudeNetLoadOptions() : base(img => new[] { 1, img.Height, img.Width, 3 })
+    {
+        LoadPixel = LoadNudeNetPixels;
     }
 
-    public class BodyPixLoadOptions : TensorLoadOptions<float> {
-        public BodyPixLoadOptions() : base(img => new[] { 1,640, 360, 3}) {
-            LoadPixel = LoadBodyPixPixels;
-        }
+    private void LoadNudeNetPixels(Tensor<float> data, Point point, ref Rgba32 pixel)
+    {
+        var y = point.Y;
+        var x = point.X;
+        data[0, y, x, 0] = pixel.B - 103.939F;
+        data[0, y, x, 1] = pixel.G - 116.779F;
+        data[0, y, x, 2] = pixel.R - 123.68F;
+    }
+}
 
-        private void LoadBodyPixPixels(Tensor<float> data, Point point, ref Rgba32 pixel) {
-            var y = point.Y;
-            var x = point.X;
-            data[0, y, x, 0] = pixel.B - 123.15F;
-            data[0, y, x, 1] = pixel.G - 115.90F;
-            data[0, y, x, 2] = pixel.R - 103.06F;
-        }
+public class BodyPixLoadOptions : TensorLoadOptions<float>
+{
+    public BodyPixLoadOptions() : base(img => new[] { 1, 640, 360, 3 })
+    {
+        LoadPixel = LoadBodyPixPixels;
     }
 
-    public class RobustVideoOptions : TensorLoadOptions<float> {
-        public RobustVideoOptions() : base(img => new[] { 1, 3, img.Height, img.Width})
+    private void LoadBodyPixPixels(Tensor<float> data, Point point, ref Rgba32 pixel)
+    {
+        var y = point.Y;
+        var x = point.X;
+        data[0, y, x, 0] = pixel.B - 123.15F;
+        data[0, y, x, 1] = pixel.G - 115.90F;
+        data[0, y, x, 2] = pixel.R - 103.06F;
+    }
+}
+
+public class RobustVideoOptions : TensorLoadOptions<float>
+{
+    public RobustVideoOptions() : base(img => new[] { 1, 3, img.Height, img.Width })
+    {
+        LoadPixel = LoadRobustVideoPixels;
+    }
+
+    private void LoadRobustVideoPixels(Tensor<float> data, Point point, ref Rgba32 pixel)
+    {
+        var y = point.Y;
+        var x = point.X;
+        data[0, 0, y, x] = pixel.B / 255F;
+        data[0, 1, y, x] = pixel.G / 255F;
+        data[0, 2, y, x] = pixel.R / 255F;
+    }
+
+    public override IEnumerable<NamedOnnxValue> GetFeeds(InferenceSession session, InputImage<float> input)
+    {
+        var ratio = new DenseTensor<float>(1);
+        var img = input.Image.SampledImage ?? input.Image.SourceImage;
+        ratio[0] = Math.Max(0.25F, 480F / (Math.Max(img.Width, img.Height)));
+        var dict = new Dictionary<string, Tensor<float>>()
         {
-            LoadPixel = LoadRobustVideoPixels;
-        }
+            ["src"] = input.Tensor,
+            ["r1i"] = new DenseTensor<float>(new[] { 1, 1, 1, 1 }),
+            ["r2i"] = new DenseTensor<float>(new[] { 1, 1, 1, 1 }),
+            ["r3i"] = new DenseTensor<float>(new[] { 1, 1, 1, 1 }),
+            ["r4i"] = new DenseTensor<float>(new[] { 1, 1, 1, 1 }),
+            ["downsample_ratio"] = ratio
+        };
+        return session.InputMetadata.Select(im => NamedOnnxValue.CreateFromTensor(im.Key, dict[im.Key]));
+    }
+}
 
-        private void LoadRobustVideoPixels(Tensor<float> data, Point point, ref Rgba32 pixel) {
-            var y = point.Y;
-            var x = point.X;
-            data[0, 0, y, x] = pixel.B / 255F;
-            data[0, 1, y, x] = pixel.G / 255F;
-            data[0, 2, y, x] = pixel.R / 255F;
-        }
-
-        public override IEnumerable<NamedOnnxValue> GetFeeds(InferenceSession session, InputImage<float> input) {
-            var ratio = new DenseTensor<float>(1);
-            var img = input.Image.SampledImage ?? input.Image.SourceImage;
-            ratio[0] = Math.Max(0.25F, 480F/(Math.Max(img.Width, img.Height)));
-            var dict = new Dictionary<string, Tensor<float>>() {
-                ["src"] = input.Tensor,
-                ["r1i"] = new DenseTensor<float>(new[] {1,1,1,1}),
-                ["r2i"] = new DenseTensor<float>(new[] {1,1,1,1}),
-                ["r3i"] = new DenseTensor<float>(new[] {1,1,1,1}),
-                ["r4i"] = new DenseTensor<float>(new[] {1,1,1,1}),
-                ["downsample_ratio"] = ratio
-            };
-            return session.InputMetadata.Select(im => NamedOnnxValue.CreateFromTensor(im.Key, dict[im.Key]));
-        }
+public class FaceDetectionLoadOptions : TensorLoadOptions<float>
+{
+    public FaceDetectionLoadOptions() : base(img => new[] { 1, 3, img.Height, img.Width })
+    {
+        LoadPixel = LoadLandmarkPixels;
     }
 
-    public class FaceDetectionLoadOptions : TensorLoadOptions<float> {
-        public FaceDetectionLoadOptions() : base(img => new[] {1, 3, img.Height, img.Width}) {
-            LoadPixel = LoadLandmarkPixels;
-        }
+    private void LoadLandmarkPixels(Tensor<float> data, Point point, ref Rgba32 pixel)
+    {
+        var y = point.Y;
+        var x = point.X;
+        data[0, 0, y, x] = (pixel.B - 127F) / 128;
+        data[0, 1, y, x] = (pixel.G - 127F) / 128;
+        data[0, 2, y, x] = (pixel.R - 127F) / 128;
+    }
+}
 
-        private void LoadLandmarkPixels(Tensor<float> data, Point point, ref Rgba32 pixel) {
-            var y = point.Y;
-            var x = point.X;
-            data[0, 0, y, x] = (pixel.B - 127F)/128;
-            data[0, 1, y, x] = (pixel.G - 127F)/128;
-            data[0, 2, y, x] = (pixel.R - 127F)/128;
-        }
+public class LandmarksLoadOptions : TensorLoadOptions<float>
+{
+    public LandmarksLoadOptions() : base(img => new[] { 1, 3, 112, 112 })
+    {
+        LoadPixel = LoadLandmarkPixels;
     }
 
-    public class LandmarksLoadOptions : TensorLoadOptions<float> {
-        public LandmarksLoadOptions() : base(img => new[] {1, 3, 112, 112}) {
-            LoadPixel = LoadLandmarkPixels;
-        }
-
-        private void LoadLandmarkPixels(Tensor<float> data, Point point, ref Rgba32 pixel) {
-            var y = point.Y;
-            var x = point.X;
-            data[0, 0, y, x] = pixel.B / 255F;
-            data[0, 1, y, x] = pixel.G / 255F;
-            data[0, 2, y, x] = pixel.R / 255F;
-        }
+    private void LoadLandmarkPixels(Tensor<float> data, Point point, ref Rgba32 pixel)
+    {
+        var y = point.Y;
+        var x = point.X;
+        data[0, 0, y, x] = pixel.B / 255F;
+        data[0, 1, y, x] = pixel.G / 255F;
+        data[0, 2, y, x] = pixel.R / 255F;
     }
 }


### PR DESCRIPTION
### Main changes
The current version of ImageSharp (2.1.3) is very outdated and  vulnerable (https://devhub.checkmarx.com/cve-details/CVE-2024-27929/).  It has been updated alongside implementing any breaking changes that have come in the 3.x versions of ImageSharp. The other dependencies have also been bumped to work well with .net 8.

### Additional info
A small change was also made to LoadImage (sorry I couldn't include this in a separate PR) to directly Load the image as a file path if the supplied path was identified as one. This fixes an issue I was encountering on linux where `Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out var uri)` would throw an exception on linux, complaining about the path being a relative path (even if it isn't)
> Reference:
https://github.com/Zekiah-A/CensorCore/blob/1b5161785e62510e933719551beba8ebcc2183a4/src/CensorCore/ImageSharpHandler.cs#L47C1-L50C14
```cs
public async Task<ImageData> LoadImage(string path)
{

    if (path.StartsWith("data:"))
    {
        ...
    }
    if (File.Exists(path)) 
    {
        return await LoadImageData(await File.ReadAllBytesAsync(path));
    }
    if (Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out var uri))
    {
        ...
    }
    ...
```